### PR TITLE
Add backend requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ python -m venv venv
 source venv/bin/activate
 ```
 
-2. Install dependencies (FastAPI, SQLAlchemy and others):
+2. Install dependencies:
 
 ```bash
-pip install -r requirements.txt
+pip install -r backend/requirements.txt
 ```
 
 3. Start the development server:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+SQLAlchemy
+pydantic
+pydantic-settings
+passlib[bcrypt]
+python-jose[cryptography]
+uvicorn


### PR DESCRIPTION
## Summary
- add list of backend dependencies in `backend/requirements.txt`
- update README backend setup instructions to use the requirements file

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6858334ba078832487ab6ecc67ab8a0e