### PR TITLE
Fix README backend start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ source venv/bin/activate
 pip install -r backend/requirements.txt
 ```
 
-3. Start the development server:
+3. Start the development server **from inside** the `backend/` directory to avoid
+   `ModuleNotFoundError`:
 
 ```bash
-uvicorn app.main:app --reload
+cd backend && uvicorn app.main:app --reload
 ```
 
 ### Environment Variables


### PR DESCRIPTION
## Summary
- document needing to run `uvicorn` from `backend/`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6858386234588324926e51004bc68adc