### PR TITLE
Fix network crash by requesting INTERNET permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name="com.psy.dear.core.App"
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- request `INTERNET` permission in AndroidManifest

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68583d659c3c8324b5e2eb91ecdd50e7