### PR TITLE
Fix base API URL for Android

### DIFF
--- a/app/src/main/java/com/psy/dear/di/NetworkModule.kt
+++ b/app/src/main/java/com/psy/dear/di/NetworkModule.kt
@@ -17,7 +17,9 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
-    private const val BASE_URL = "https://ganti.dengan.url.backend.anda/"
+    // Base URL for the FastAPI backend. Adjust as needed for your environment.
+    // Use 10.0.2.2 when running on an Android emulator to reach localhost.
+    private const val BASE_URL = "http://10.0.2.2:8000/api/v1/"
 
     @Provides
     @Singleton


### PR DESCRIPTION
## Summary
- replace placeholder API base URL with `10.0.2.2` so the app can reach the local FastAPI backend
- add comment clarifying how to adjust the base URL for different environments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68583e5db4a88324940f55de9255e62f