### PR TITLE
Fix JWT exception handling

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,7 +1,7 @@
 from typing import Generator
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
-from jose import jwt
+from jose import JWTError, jwt
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
@@ -22,7 +22,7 @@ def get_current_user(db: Session = Depends(get_db), token: str = Depends(reusabl
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
         token_data = schemas.TokenPayload(**payload)
-    except (jwt.JWTError, ValidationError):
+    except (JWTError, ValidationError):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Could not validate credentials",


### PR DESCRIPTION
## Summary
- import JWTError from jose
- handle JWTError directly in token parsing

## Testing
- `python -m pip install -r backend/requirements.txt`
- `uvicorn app.main:app --reload` *(fails until additional dependencies installed)*
- `python -m pip install email_validator`
- `python -m pip install python-multipart`
- `uvicorn app.main:app --reload`

------
https://chatgpt.com/codex/tasks/task_e_685840cd216883248ec4c1b07a717539