### PR TITLE
Create tables on startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,17 @@
 from app.api.api import api_router
 from fastapi import FastAPI
 
+from app.db.session import engine
+from app.models import *  # noqa
+from app.db.base_class import Base
+
 app = FastAPI(title="Dear Diary API")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Create database tables on startup."""
+    Base.metadata.create_all(bind=engine)
 
 app.include_router(api_router, prefix="/api/v1")
 


### PR DESCRIPTION
## Summary
- ensure DB tables exist when FastAPI starts

## Testing
- `pip install -r backend/requirements.txt` *(fails: cython build issue)*

------
https://chatgpt.com/codex/tasks/task_e_685844914040832481ee6f53570f2de0