### PR TITLE
Allow JSON login

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 
 from app import crud, schemas
@@ -22,11 +21,12 @@ def register(
 
 @router.post("/login", response_model=schemas.Token)
 def login(
+    *,
     db: Session = Depends(get_db),
-    form_data: OAuth2PasswordRequestForm = Depends(),
+    login_in: schemas.UserLogin,
 ):
-    user = crud.user.get_by_email(db, email=form_data.username)
-    if not user or not verify_password(form_data.password, user.hashed_password):
+    user = crud.user.get_by_email(db, email=login_in.email)
+    if not user or not verify_password(login_in.password, user.hashed_password):
         raise HTTPException(status_code=400, detail="Incorrect email or password")
 
     access_token = create_access_token(user.id)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,4 +1,4 @@
-from .user import UserBase, UserCreate, UserUpdate, UserInDB, UserPublic
+from .user import UserBase, UserCreate, UserUpdate, UserInDB, UserPublic, UserLogin
 from .journal import JournalBase, JournalCreate, JournalUpdate, JournalInDB
 from .token import Token, TokenPayload
 from .chat import ChatMessage, ChatResponse
@@ -9,6 +9,7 @@ __all__ = [
     "UserUpdate",
     "UserInDB",
     "UserPublic",
+    "UserLogin",
     "JournalBase",
     "JournalCreate",
     "JournalUpdate",

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -20,3 +20,7 @@ class UserInDB(UserBase):
 
 class UserPublic(UserBase):
     id: int
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str


### PR DESCRIPTION
## Summary
- add `UserLogin` schema and export it
- accept JSON body for `/auth/login`

## Testing
- `pytest`
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6858463a90cc8324ad77e06d3253176a