### PR TITLE
Implement chat endpoint

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter
-from app.api.v1 import auth, journal
+from app.api.v1 import auth, journal, chat
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(journal.router, prefix="/journals", tags=["journals"])
+api_router.include_router(chat.router, prefix="/chat", tags=["chat"])
+

--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Depends
+
+from app import models, schemas
+from app.dependencies import get_current_user
+
+router = APIRouter()
+
+@router.post("/", response_model=schemas.ChatResponse)
+def create_chat_message(
+    *,
+    message_in: schemas.ChatMessage,
+    current_user: models.User = Depends(get_current_user),
+):
+    """Simple chat endpoint that echoes back the provided message."""
+    reply = f"You said: {message_in.message}" 
+    return schemas.ChatResponse(reply=reply)
+


### PR DESCRIPTION
## Summary
- add a simple `/chat` route that echoes the request
- wire the chat router into the API

## Testing
- `gradle test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685848352bfc832496e4fe5e671d6608