### PR TITLE
Remove plugin block from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-plugins {
-alias(libs.plugins.android.application) apply false
-alias(libs.plugins.kotlin.android) apply false
-alias(libs.plugins.hilt.android) apply false
-alias(libs.plugins.kotlin.kapt) apply false
 android.useAndroidX=true
 android.enableJetifier=true
-
-}
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
## Summary
- remove the `plugins` section from `gradle.properties`

## Testing
- `./gradlew --version` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68585d8220308324a4b72db3c0cb8c0e