### PR TITLE
Implement journal detail navigation

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
@@ -56,7 +56,7 @@ fun HomeScreen(
                     items(state.journals, key = { it.id }) { journal ->
                         JournalItem(
                             journal = journal,
-                            onClick = { /* TODO: Navigate to detail */ }
+                            onClick = { navController.navigate(Screen.JournalDetail.createRoute(journal.id)) }
                         )
                     }
                 }

--- a/app/src/main/java/com/psy/dear/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/main/MainScreen.kt
@@ -11,6 +11,7 @@ import com.psy.dear.presentation.chat.ChatScreen
 import com.psy.dear.presentation.growth.GrowthScreen
 import com.psy.dear.presentation.home.HomeScreen
 import com.psy.dear.presentation.journal_editor.JournalEditorScreen
+import com.psy.dear.presentation.journal_detail.JournalDetailScreen
 import com.psy.dear.presentation.navigation.Screen
 import com.psy.dear.presentation.profile.ProfileScreen
 import com.psy.dear.presentation.services.ServicesScreen
@@ -55,6 +56,7 @@ fun MainScreen() {
             composable(Screen.Profile.route) { ProfileScreen(navController = mainNavController) }
 
             composable(Screen.JournalEditor.route) { JournalEditorScreen(navController = mainNavController) }
+            composable(Screen.JournalDetail.route) { JournalDetailScreen(navController = mainNavController) }
         }
     }
 }

--- a/app/src/main/java/com/psy/dear/presentation/navigation/Navigation.kt
+++ b/app/src/main/java/com/psy/dear/presentation/navigation/Navigation.kt
@@ -35,6 +35,10 @@ sealed class Screen(val route: String, val title: String? = null, val icon: Imag
     object JournalEditor : Screen("journal_editor?journalId={journalId}") {
         fun createRoute(journalId: String?): String = "journal_editor?journalId=$journalId"
     }
+
+    object JournalDetail : Screen("journal_detail/{journalId}") {
+        fun createRoute(journalId: String): String = "journal_detail/$journalId"
+    }
 }
 
 @OptIn(ExperimentalAnimationApi::class)


### PR DESCRIPTION
## Summary
- add `JournalDetail` route for navigating to journal detail entries
- wire up detail composable in the main navigation graph
- open journal detail when a journal is tapped on the Home screen

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68585f27b8208324900003eb290a6dd4