### PR TITLE
Fix ChatViewModel error branch

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatViewModel.kt
@@ -55,7 +55,10 @@ class ChatViewModel @Inject constructor(
                         // For now, let's assume we need to refetch or the response gives us what we need
                     }
                     is Result.Error -> {
-                        uiState = uiState.copy(error = result.message ?: "An unknown error occurred")
+                        uiState = uiState.copy(error = result.exception?.message ?: "An unknown error occurred")
+                    }
+                    is Result.Loading -> {
+                        // No-op: loading state is handled outside this scope
                     }
                 }
             } finally {


### PR DESCRIPTION
## Summary
- fix exhaustive `when` in `ChatViewModel`
- use `result.exception?.message` for error message
- include `Result.Loading` handling

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586845ba44832499f9bb65bed6f6ec