### PR TITLE
Handle unauthorized chat

### DIFF
--- a/app/src/main/java/com/psy/dear/core/UnauthorizedException.kt
+++ b/app/src/main/java/com/psy/dear/core/UnauthorizedException.kt
@@ -1,0 +1,3 @@
+package com.psy.dear.core
+
+class UnauthorizedException : Exception("Unauthorized")

--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
@@ -29,14 +29,30 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import kotlinx.coroutines.flow.collectLatest
 import com.psy.dear.domain.model.ChatMessage // Pastikan untuk mengimpor model domain Anda
+import com.psy.dear.presentation.chat.ChatUiEvent
 
 @Composable
 fun ChatScreen(
+    navController: NavController,
     viewModel: ChatViewModel = hiltViewModel()
 ) {
     val uiState = viewModel.uiState
     val listState = rememberLazyListState()
+
+    LaunchedEffect(Unit) {
+        viewModel.eventFlow.collectLatest { event ->
+            when (event) {
+                ChatUiEvent.NavigateToLogin -> {
+                    navController.navigate("login") {
+                        popUpTo("main_flow") { inclusive = true }
+                    }
+                }
+            }
+        }
+    }
 
     // Scroll otomatis ke item terbaru
     LaunchedEffect(uiState.messages.size) {

--- a/app/src/main/java/com/psy/dear/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/main/MainScreen.kt
@@ -50,7 +50,7 @@ fun MainScreen() {
             modifier = Modifier.padding(innerPadding)
         ) {
             composable(Screen.Home.route) { HomeScreen(navController = mainNavController) }
-            composable(Screen.Chat.route) { ChatScreen() }
+            composable(Screen.Chat.route) { ChatScreen(navController = mainNavController) }
             composable(Screen.Growth.route) { GrowthScreen(navController = mainNavController) }
             composable(Screen.Services.route) { ServicesScreen(navController = mainNavController) }
             composable(Screen.Profile.route) { ProfileScreen(navController = mainNavController) }


### PR DESCRIPTION
## Summary
- detect HTTP 403 when posting chat messages
- clear the auth token when chat API returns 403
- signal ChatViewModel to navigate to login
- update ChatScreen and MainScreen for new navigation flow
- add UnauthorizedException class

## Testing
- `./gradlew test --quiet` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68586b5df8988324b18defb082fc57fa