### PR TITLE
Fix chat content mapping in ChatResponse

### DIFF
--- a/app/src/main/java/com/psy/dear/data/network/dto/Dtos.kt
+++ b/app/src/main/java/com/psy/dear/data/network/dto/Dtos.kt
@@ -20,7 +20,10 @@ data class CreateJournalRequest(val title: String, val content: String, val mood
 
 // ChatDtos
 data class ChatRequest(val message: String)
-data class ChatResponse(val reply: String)
+data class ChatResponse(
+    @SerializedName("content")
+    val reply: String
+)
 
 // UserDtos
 data class UserProfileResponse(


### PR DESCRIPTION
## Summary
- map `content` JSON field from the backend to `ChatResponse.reply`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b72eb42c8324936a4a03216baa12