### PR TITLE
Refactor conversation techniques

### DIFF
--- a/backend/app/schemas/plan.py
+++ b/backend/app/schemas/plan.py
@@ -1,18 +1,17 @@
-
 from enum import Enum
 from pydantic import BaseModel, Field
 
 class CommunicationTechnique(str, Enum):
+    """Enumeration of communication techniques Dear can apply."""
+
+    SOCIAL_GREETING = "social_greeting"
     PROBING = "probing"
-    CLARIFYING = "clarifying"
-    PARAPHRASING = "paraphrasing"
-    REFLECTING = "reflecting"
-    OPEN_ENDED_QUESTIONS = "open_ended_questions"
-    CLOSED_ENDED_QUESTIONS = "closed_ended_questions"
+    VALIDATION = "validation"
+    EMPATHETIC = "empathetic"
+    REFLECTION = "reflection"
     SUMMARIZING = "summarizing"
-    CONFRONTATION = "confrontation"
-    REASSURANCE_ENCOURAGEMENT = "reassurance_encouragement"
-    # Tambahkan 'UNKNOWN' sebagai fallback
+    CLARIFYING = "clarifying"
+    # Fallback option when the planner cannot determine the technique
     UNKNOWN = "unknown"
 
 class ConversationPlan(BaseModel):

--- a/backend/app/services/generator_service.py
+++ b/backend/app/services/generator_service.py
@@ -12,18 +12,16 @@ class GeneratorService:
         self.api_base_url = "https://openrouter.ai/api/v1"
         self.log = structlog.get_logger(__name__)
 
-        # Definisikan TOOLBOX di sini
+        # Brief instructions for applying each communication technique
         self.TOOLBOX = {
-            "probing": "ask a short, gentle clarifying question to explore a specific part of the user's message.",
-            "clarifying": "confirm your understanding of the user's message to ensure you are on the same page.",
-            "paraphrasing": "rephrase the user's core message in your own words to show you are listening.",
-            "reflecting": "briefly mirror the primary emotion you detect in the user's message.",
-            "open_ended_questions": "ask a broad, open-ended question to invite the user to share more details if they wish.",
-            "closed_ended_questions": "ask a concise yes-or-no question to confirm a specific detail from the user's message.",
-            "summarizing": "provide a brief, neutral summary of the key points the user has made.",
-            "confrontation": "gently point out a discrepancy you've noticed and invite the user to clarify.",
-            "reassurance_encouragement": "offer a short, gentle, and non-specific message of reassurance or encouragement.",
-            "unknown": "ask a simple, open-ended question like 'How are you feeling about that?' or 'Can you tell me more?'"
+            "social_greeting": "start with a warm, friendly greeting to set a comfortable tone.",
+            "probing": "ask a short clarifying question to gently explore the user's message.",
+            "validation": "acknowledge that the user's feelings or viewpoint make sense.",
+            "empathetic": "show empathy so the user feels heard and understood.",
+            "reflection": "mirror back the main feeling or idea you heard.",
+            "summarizing": "briefly recap the key points shared by the user.",
+            "clarifying": "confirm your understanding of what the user said.",
+            "unknown": "ask a simple open question like 'Could you tell me more?'"
         }
 
     async def _call_openrouter(self, model: str, messages: List[Dict[str, str]]) -> Dict:


### PR DESCRIPTION
## Summary
- update communication techniques enumeration
- provide brief instructions for new techniques in generator

## Testing
- `python -m py_compile backend/app/schemas/plan.py backend/app/services/generator_service.py backend/app/services/planner_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6858d017690483248576adae6a903d85