### PR TITLE
Update chat planner to use string history

### DIFF
--- a/backend/app/services/planner_service.py
+++ b/backend/app/services/planner_service.py
@@ -30,7 +30,7 @@ class PlannerService:
     async def get_plan(
         self,
         user_message: str,
-        chat_history: List[Dict[str, str]],
+        chat_history: List[str],
         latest_journal: str,
     ) -> ConversationPlan:
         """Determine which counseling technique Dear should apply next."""
@@ -41,7 +41,7 @@ class PlannerService:
             f"'{t.value}'" for t in CommunicationTechnique if t != CommunicationTechnique.UNKNOWN
         )
 
-        history_str = "\n".join(f"{m['role']}: {m['content']}" for m in chat_history)
+        history_str = "\n".join(chat_history)
 
         prompt = (
             "You are Dear's planning counselor. Choose the best next counseling "


### PR DESCRIPTION
## Summary
- collect chat history as a list of strings
- send chat history and latest journal to `PlannerService`
- adjust `PlannerService` to accept list of strings

## Testing
- `python -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_e_6858d0e8a0cc8324854c9db02197bf9d