### PR TITLE
Add information technique and update planner prompt

### DIFF
--- a/backend/app/schemas/plan.py
+++ b/backend/app/schemas/plan.py
@@ -11,6 +11,7 @@ class CommunicationTechnique(str, Enum):
     REFLECTION = "reflection"
     SUMMARIZING = "summarizing"
     CLARIFYING = "clarifying"
+    INFORMATION = "information"
     # Fallback option when the planner cannot determine the technique
     UNKNOWN = "unknown"
 

--- a/backend/app/services/generator_service.py
+++ b/backend/app/services/generator_service.py
@@ -20,6 +20,7 @@ class GeneratorService:
             "reflection": "mirror back the main feeling or idea you heard.",
             "summarizing": "briefly recap the key points shared by the user.",
             "clarifying": "confirm your understanding of what the user said.",
+            "information": "Jawab pertanyaan pengguna secara langsung, singkat, dan jujur berdasarkan riwayat percakapan kita.",
             "unknown": "ask a simple open question like 'Could you tell me more?'"
         }
 

--- a/backend/app/services/planner_service.py
+++ b/backend/app/services/planner_service.py
@@ -42,15 +42,26 @@ class PlannerService:
 
         history_str = "\n".join(chat_history)
 
-        prompt = (
-            "You are Dear's planning counselor. Choose the best next counseling "
-            "technique for Dear to use when replying.\n"
-            f"Strategies: [{available_techniques}]\n\n"
-            f"Latest journal entry: {latest_journal or 'None'}\n"
-            f"Chat history:\n{history_str}\n"
-            f"User message: {user_message}\n\n"
-            "Respond ONLY with a JSON object like {\"technique\": \"<name>\"}."
-        )
+        prompt = f"""
+Anda adalah konselor perencana untuk Dear. Analisis riwayat percakapan dan pesan pengguna, kemudian pilih SATU teknik komunikasi yang paling sesuai.
+
+Kategorikan pesan pengguna ke dalam salah satu dari empat tipe berikut:
+1. Salam atau basa-basi.
+2. Curhat atau ungkapan perasaan.
+3. Pertanyaan informasi.
+4. Tidak jelas atau di luar konteks.
+
+Gunakan toolbox teknik di bawah ini dan pilih satu strategi saja:
+{available_techniques}
+- information: Jawab pertanyaan pengguna secara langsung, singkat, dan jujur.
+
+Entri jurnal terbaru: {latest_journal or 'Tidak ada'}
+Riwayat chat:
+{history_str}
+Pesan pengguna: {user_message}
+
+Balas HANYA dengan objek JSON sederhana seperti {{"technique": "<name>"}}.
+"""
 
         messages = [{"role": "system", "content": prompt}]
 


### PR DESCRIPTION
## Summary
- add `INFORMATION` enum value
- document new technique in generator service toolbox
- rewrite planner prompt in Indonesian to mention new strategy

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6858d84643e48324b38e1307b74be713