### PR TITLE
Use SenderType enum in chat schema

### DIFF
--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -1,11 +1,12 @@
 from pydantic import BaseModel, ConfigDict
 from typing import Optional
 from datetime import datetime
+from app.models.chat import SenderType
 
 # Skema dasar untuk field yang sama di semua varian
 class ChatMessageBase(BaseModel):
     content: str
-    sender_type: str  # Anda bisa menggunakan Enum di sini jika mau
+    sender_type: SenderType
     ai_technique: Optional[str] = None
 
 


### PR DESCRIPTION
## Summary
- use `SenderType` enum in `ChatMessageBase`
- adjust API to use `SenderType` when creating messages
- output enum values when sending history to generator service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858d98e21a483248029e8e0a2050393