### PR TITLE
Update generator prompt with grounding rules

### DIFF
--- a/backend/app/services/generator_service.py
+++ b/backend/app/services/generator_service.py
@@ -48,7 +48,10 @@ class GeneratorService:
             "1. Gunakan HANYA teknik yang diberikan.\n"
             "2. JANGAN memberi nasihat.\n"
             "3. JANGAN menilai atau menganalisis.\n"
-            "4. Buatlah singkat dan natural.\n\n"
+            "4. Buatlah singkat dan natural.\n"
+            "5. Jawab hanya berdasarkan informasi yang diberikan pengguna.\n"
+            "6. Jangan menebak atau menambahkan detail yang tidak disebutkan.\n"
+            "7. Keep replies 1-2 sentences long.\n\n"
             f"**Teknik:** {plan.technique.value}\n"
             f"**Cara menerapkan:** {technique_instruction}"
         )


### PR DESCRIPTION
## Summary
- expand the system prompt in `GeneratorService` with stricter rules

## Testing
- `pytest -q`
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6858e4978c908324bab9a610e95ced03