### PR TITLE
Fix chat history duplication

### DIFF
--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -57,7 +57,11 @@ async def handle_chat_message(
     )
 
     # 4. Panggil Generator untuk mendapatkan respons final
-    final_response = await generator.generate_response(conversation_plan, history_formatted, chat_in.message)
+    # history_formatted already contains the latest user message so we don't
+    # need to send it separately to the GeneratorService
+    final_response = await generator.generate_response(
+        conversation_plan, history_formatted
+    )
 
     # 5. Simpan respons AI ke database
     ai_message_obj = schemas.chat.ChatMessageCreate(

--- a/backend/app/services/generator_service.py
+++ b/backend/app/services/generator_service.py
@@ -41,7 +41,7 @@ class GeneratorService:
             return response.json()
 
     async def generate_response(
-        self, plan: ConversationPlan, history: List[Dict], user_message: str
+        self, plan: ConversationPlan, history: List[Dict]
     ) -> str:
         self.log.info("generating_response", technique=plan.technique.value)
 
@@ -52,6 +52,9 @@ class GeneratorService:
         chat_history_str = "\n".join(
             f"{msg['role']}: {msg['content']}" for msg in history
         )
+
+        # The user's latest message is the last item in the history list
+        user_message = history[-1]["content"] if history else ""
 
         prompt = (
             'Kamu adalah "Dear", teman bicara virtual premium yang suportif dan responsif secara emosional. '
@@ -67,7 +70,6 @@ class GeneratorService:
 
         messages = [{"role": "system", "content": prompt}]
         messages.extend(history)
-        messages.append({"role": "user", "content": user_message})
 
         try:
             data = await self._call_openrouter(

--- a/backend/tests/test_generator_service.py
+++ b/backend/tests/test_generator_service.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.services.generator_service import GeneratorService
+
+
+class DummyTechnique:
+    def __init__(self, value: str):
+        self.value = value
+
+
+class DummyPlan:
+    def __init__(self, technique: str):
+        self.technique = DummyTechnique(technique)
+
+@pytest.mark.asyncio
+async def test_generate_response_no_duplicate(monkeypatch):
+    captured = {}
+
+    async def fake_call(self, model, messages):
+        captured['messages'] = messages
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    monkeypatch.setattr(GeneratorService, "_call_openrouter", fake_call)
+
+    plan = DummyPlan("information")
+    history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": "how are you?"},
+    ]
+
+    from app.core.config import settings as app_settings
+    service = GeneratorService(settings=app_settings)
+    response = await service.generate_response(plan, history)
+
+    assert response == "ok"
+    # first message is the system prompt
+    assert captured['messages'][1:] == history
+    # ensure no duplicate of the latest user message
+    assert len(captured['messages']) == len(history) + 1
+    assert "how are you?" in captured['messages'][0]['content']


### PR DESCRIPTION
## Summary
- stop passing user message separately to generator
- fetch latest user message from history inside generator
- ensure GeneratorService prompt doesn't duplicate
- add unit test for GeneratorService

## Testing
- `pip install -r backend/requirements.txt`
- `pip install email-validator`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f3c297148324ab5bf6c51c700997