### PR TITLE
Remove unused HTTPException imports

### DIFF
--- a/backend/app/services/generator_service.py
+++ b/backend/app/services/generator_service.py
@@ -1,7 +1,7 @@
 import httpx
 import structlog
 from typing import List, Dict
-from fastapi import Depends, HTTPException
+from fastapi import Depends
 from app.core.config import Settings, settings
 from app.schemas.plan import ConversationPlan
 

--- a/backend/app/services/planner_service.py
+++ b/backend/app/services/planner_service.py
@@ -2,7 +2,7 @@ import httpx
 import json
 import structlog
 from typing import List, Dict
-from fastapi import Depends, HTTPException
+from fastapi import Depends
 from app.core.config import Settings, settings
 from app.schemas.plan import CommunicationTechnique, ConversationPlan
 


### PR DESCRIPTION
## Summary
- clean up generator and planner service imports
- ensure no unused HTTPException imports remain

## Testing
- `flake8 backend/app/services/planner_service.py backend/app/services/generator_service.py | head -n 5`
- `flake8 backend/app/services/planner_service.py backend/app/services/generator_service.py | tail -n 10`

------
https://chatgpt.com/codex/tasks/task_e_6858f5137984832484cdae0878aa3c47