### PR TITLE
Add backend chat tests and CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,19 @@
+name: Backend Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest backend/tests

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ python-jose[cryptography]
 uvicorn
 httpx>=0.27.0
 structlog>=24.1.0
+email-validator

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,49 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.dependencies import get_db, get_current_user
+from app.db.base_class import Base
+from app.models.user import User
+
+@pytest.fixture
+def temp_session(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield TestingSessionLocal
+    Base.metadata.drop_all(bind=engine)
+    engine.dispose()
+
+@pytest.fixture
+def client(temp_session):
+    # create a user
+    db = temp_session()
+    user = User(username="tester", email="tester@example.com", hashed_password="fake")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    db.expunge(user)
+    db.close()
+
+    def override_get_db():
+        db = temp_session()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def override_get_current_user():
+        return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    client = TestClient(app)
+    yield client, temp_session
+    app.dependency_overrides = {}
+

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -1,0 +1,39 @@
+import pytest
+from app.schemas.plan import CommunicationTechnique, ConversationPlan
+from app.services.planner_service import PlannerService
+from app.services.generator_service import GeneratorService
+
+
+def test_chat_flow_success(client):
+    client_app, session_local = client
+
+    class DummyPlanner:
+        async def get_plan(self, *args, **kwargs):
+            return ConversationPlan(technique=CommunicationTechnique.INFORMATION)
+
+    class DummyGenerator:
+        async def generate_response(self, plan, history, emotion):
+            return "hello from ai"
+
+    from app.main import app
+    app.dependency_overrides[PlannerService] = lambda: DummyPlanner()
+    app.dependency_overrides[GeneratorService] = lambda: DummyGenerator()
+
+    response = client_app.post("/api/v1/chat/", json={"message": "Hi"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["content"] == "hello from ai"
+    assert data["sender_type"] == "ai"
+    assert data["ai_technique"] == "information"
+
+    from app.models.chat import ChatMessage
+    db = session_local()
+    try:
+        msgs = db.query(ChatMessage).all()
+        assert len(msgs) == 2
+    finally:
+        db.close()
+
+    app.dependency_overrides.pop(PlannerService, None)
+    app.dependency_overrides.pop(GeneratorService, None)
+

--- a/backend/tests/test_generator_service.py
+++ b/backend/tests/test_generator_service.py
@@ -35,7 +35,7 @@ async def test_generate_response_no_duplicate(monkeypatch):
 
     from app.core.config import settings as app_settings
     service = GeneratorService(settings=app_settings)
-    response = await service.generate_response(plan, history)
+    response = await service.generate_response(plan, history, "neutral")
 
     assert response == "ok"
     # first message is the system prompt

--- a/backend/tests/test_openrouter_credentials.py
+++ b/backend/tests/test_openrouter_credentials.py
@@ -1,0 +1,28 @@
+import pytest
+import httpx
+from app.services.planner_service import PlannerService
+from app.services.generator_service import GeneratorService
+from app.schemas.plan import CommunicationTechnique, ConversationPlan
+from app.core.config import Settings
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("api_key", [None, "bad-key"])
+async def test_services_handle_invalid_credentials(monkeypatch, api_key):
+    planner = PlannerService(settings=Settings(OPENROUTER_API_KEY=api_key))
+    generator = GeneratorService(settings=Settings(OPENROUTER_API_KEY=api_key))
+
+    async def raise_error(self, model, messages):
+        request = httpx.Request("POST", "https://openrouter.ai")
+        response = httpx.Response(status_code=401, request=request)
+        raise httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+    monkeypatch.setattr(PlannerService, "_call_openrouter", raise_error)
+    monkeypatch.setattr(GeneratorService, "_call_openrouter", raise_error)
+
+    plan = await planner.get_plan("hi", [], "", "neutral")
+    assert plan.technique == CommunicationTechnique.UNKNOWN
+
+    result = await generator.generate_response(plan, [], "neutral")
+    assert "listen" in result.lower()
+


### PR DESCRIPTION
## Summary
- add workflow to run backend pytest suite
- create pytest fixtures for temporary DB and API client
- test chat message flow with mocked planner & generator
- validate error handling for missing OpenRouter credentials
- fix generator service test to match new signature
- include email-validator dependency

## Testing
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f79e1dc08324bb2cbca14be15aa9