### PR TITLE
Add Room migration for chat messages

### DIFF
--- a/app/src/main/java/com/psy/dear/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/psy/dear/data/local/AppDatabase.kt
@@ -3,6 +3,8 @@ package com.psy.dear.data.local
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.psy.dear.data.local.dao.ChatMessageDao
 import com.psy.dear.data.local.dao.JournalDao
 import com.psy.dear.data.local.entity.ChatMessageEntity
@@ -17,4 +19,20 @@ import com.psy.dear.data.local.entity.JournalEntity
 abstract class AppDatabase : RoomDatabase() {
     abstract fun journalDao(): JournalDao
     abstract fun chatMessageDao(): ChatMessageDao
+
+    companion object {
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `chat_messages` (" +
+                        "`id` TEXT NOT NULL, " +
+                        "`role` TEXT NOT NULL, " +
+                        "`content` TEXT NOT NULL, " +
+                        "`emotion` TEXT, " +
+                        "`timestamp` TEXT NOT NULL, " +
+                        "PRIMARY KEY(`id`))"
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/psy/dear/di/DatabaseModule.kt
+++ b/app/src/main/java/com/psy/dear/di/DatabaseModule.kt
@@ -23,7 +23,9 @@ object DatabaseModule {
             context,
             AppDatabase::class.java,
             "dear_diary_db"
-        ).build()
+        )
+            .addMigrations(AppDatabase.MIGRATION_1_2)
+            .build()
     }
 
     @Provides


### PR DESCRIPTION
## Summary
- create MIGRATION_1_2 to add `chat_messages` table
- register the migration in `DatabaseModule`

## Testing
- `python3 -m pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6858fd0185c483249c3f726ef095b9f2