### PR TITLE
Add pytest-asyncio to testing setup

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,6 +14,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r backend/requirements.txt
-          pip install pytest
+          pip install pytest pytest-asyncio
       - name: Run tests
         run: pytest backend/tests

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ Run the backend and then launch the Android app. The app communicates with the A
 
 The chat endpoint now performs a basic emotion analysis on each message. The detected label is saved along with the chat history and influences the AI planner and generator prompts.
 
+## Running Tests
+
+```bash
+pip install -r backend/requirements.txt
+pip install pytest pytest-asyncio
+pytest backend/tests
+```
+
 ## Contributing
 
 Contributions are welcome! Please open issues or pull requests on GitHub. Make sure to format code and provide tests where relevant.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,6 @@ uvicorn
 httpx>=0.27.0
 structlog>=24.1.0
 email-validator
+
+# Testing
+pytest-asyncio


### PR DESCRIPTION
## Summary
- add `pytest-asyncio` dependency for backend testing
- install `pytest-asyncio` in CI workflow
- document test instructions in README

## Testing
- `pytest -q backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6858fe673ff08324b2721b9941ff00c0