### PR TITLE
Fix chat message migration

### DIFF
--- a/app/src/main/java/com/psy/dear/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/psy/dear/data/local/AppDatabase.kt
@@ -12,7 +12,7 @@ import com.psy.dear.data.local.entity.JournalEntity
 
 @Database(
     entities = [JournalEntity::class, ChatMessageEntity::class],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -32,6 +32,12 @@ abstract class AppDatabase : RoomDatabase() {
                         "`timestamp` TEXT NOT NULL, " +
                         "PRIMARY KEY(`id`))"
                 )
+            }
+        }
+
+        val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `chat_messages` ADD COLUMN `emotion` TEXT")
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/di/DatabaseModule.kt
+++ b/app/src/main/java/com/psy/dear/di/DatabaseModule.kt
@@ -24,7 +24,10 @@ object DatabaseModule {
             AppDatabase::class.java,
             "dear_diary_db"
         )
-            .addMigrations(AppDatabase.MIGRATION_1_2)
+            .addMigrations(
+                AppDatabase.MIGRATION_1_2,
+                AppDatabase.MIGRATION_2_3
+            )
             .build()
     }
 


### PR DESCRIPTION
## Summary
- bump DB version to 3
- provide migration from version 2 adding the `emotion` column
- register new migration in `DatabaseModule`

## Testing
- `gradle --version`
- `gradle test` *(fails: Starting a Gradle Daemon)*

------
https://chatgpt.com/codex/tasks/task_e_685902d51cc88324a007dd38b49a7ae8