### PR TITLE
Add /users/me endpoint and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,12 @@ Before using the chat endpoint you must create an account and obtain an access t
         -H "Content-Type: application/json" \
         -d '{"email": "test@example.com", "password": "secret"}'
    ```
-3. Use the token when calling `/chat/`:
+3. Optionally verify the token by fetching the current user:
+   ```bash
+   curl http://localhost:8000/api/v1/users/me \
+        -H "Authorization: Bearer <token>"
+   ```
+4. Use the token when calling `/chat/`:
    ```bash
    curl -X POST http://localhost:8000/api/v1/chat/ \
         -H "Authorization: Bearer <token>" \

--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
-from app.api.v1 import auth, journal, chat
+from app.api.v1 import auth, journal, chat, user
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(journal.router, prefix="/journals", tags=["journals"])
 api_router.include_router(chat.router, prefix="/chat", tags=["chat"])
+api_router.include_router(user.router, tags=["users"])
 

--- a/backend/app/api/v1/user.py
+++ b/backend/app/api/v1/user.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, Depends
+
+from app import models, schemas
+from app.dependencies import get_current_user
+
+router = APIRouter()
+
+@router.get("/users/me", response_model=schemas.UserPublic)
+def read_users_me(current_user: models.User = Depends(get_current_user)):
+    return current_user

--- a/backend/tests/test_user_api.py
+++ b/backend/tests/test_user_api.py
@@ -1,0 +1,12 @@
+from app.models.user import User
+
+
+def test_get_current_user(client):
+    client_app, _ = client
+    response = client_app.get("/api/v1/users/me")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "tester"
+    assert data["email"] == "tester@example.com"
+    assert data["id"] == 1
+


### PR DESCRIPTION
## Summary
- expose current user info via `/api/v1/users/me`
- wire new router into API setup
- test that the endpoint returns the authenticated user
- document the new curl command in the authentication workflow

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859079e2c688324bf7260a3bdd01388