### PR TITLE
Add tests for auth registration and login

### DIFF
--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -1,0 +1,43 @@
+from app.models.user import User
+
+
+def test_register_creates_user(client):
+    client_app, session_local = client
+    payload = {
+        "username": "alice",
+        "email": "alice@example.com",
+        "password": "secret",
+    }
+    response = client_app.post("/api/v1/auth/register", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "alice"
+    assert data["email"] == "alice@example.com"
+    assert "id" in data
+
+    db = session_local()
+    try:
+        user = db.query(User).filter_by(email="alice@example.com").first()
+        assert user is not None
+    finally:
+        db.close()
+
+
+def test_login_returns_token(client):
+    client_app, _ = client
+    reg_payload = {
+        "username": "bob",
+        "email": "bob@example.com",
+        "password": "secret",
+    }
+    client_app.post("/api/v1/auth/register", json=reg_payload)
+
+    response = client_app.post(
+        "/api/v1/auth/login",
+        json={"email": "bob@example.com", "password": "secret"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+


### PR DESCRIPTION
## Summary
- add API tests for registration and login
- verify registration stores users and login returns tokens

## Testing
- `pytest -q backend/tests/test_auth_api.py`
- `pytest -q backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_685908edaa408324808853f41a4991b5