### PR TITLE
Update chat endpoint to include trailing slash

### DIFF
--- a/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
+++ b/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
@@ -20,7 +20,7 @@ interface JournalApiService {
 }
 
 interface ChatApiService {
-    @POST("chat")
+    @POST("chat/")
     suspend fun postMessage(@Body request: ChatRequest): ChatResponse
 }
 


### PR DESCRIPTION
## Summary
- fix ChatApiService path to post to `chat/`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590c2585a483249ae68f14285fe056