### PR TITLE
Handle unauthorized responses

### DIFF
--- a/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
@@ -127,7 +127,8 @@ class ChatRepositoryImpl @Inject constructor(
             dao.insert(assistantMessage.toEntity())
             Result.Success(Unit)
         } catch (e: HttpException) {
-            if (e.code() == 403) {
+            val code = e.code()
+            if (code == 401 || code == 403 || code == 404) {
                 prefs.clearAuthToken()
                 Result.Error(UnauthorizedException())
             } else {

--- a/app/src/test/java/com/psy/dear/data/repository/FakeChatRepository.kt
+++ b/app/src/test/java/com/psy/dear/data/repository/FakeChatRepository.kt
@@ -1,0 +1,19 @@
+package com.psy.dear.data.repository
+
+import com.psy.dear.core.Result
+import com.psy.dear.domain.model.ChatMessage
+import com.psy.dear.domain.repository.ChatRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeChatRepository : ChatRepository {
+    private val messagesFlow = MutableStateFlow<List<ChatMessage>>(emptyList())
+    var sendResult: Result<Unit> = Result.Success(Unit)
+
+    override fun getChatHistory(): Flow<List<ChatMessage>> = messagesFlow.asStateFlow()
+
+    override suspend fun sendMessage(message: String): Result<Unit> {
+        return sendResult
+    }
+}

--- a/app/src/test/java/com/psy/dear/presentation/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/dear/presentation/chat/ChatViewModelTest.kt
@@ -1,0 +1,47 @@
+package com.psy.dear.presentation.chat
+
+import app.cash.turbine.test
+import com.psy.dear.core.Result
+import com.psy.dear.core.UnauthorizedException
+import com.psy.dear.data.repository.FakeChatRepository
+import com.psy.dear.domain.use_case.chat.GetChatHistoryUseCase
+import com.psy.dear.domain.use_case.chat.SendMessageUseCase
+import com.psy.dear.util.TestCoroutineRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@ExperimentalCoroutinesApi
+class ChatViewModelTest {
+
+    @get:Rule
+    val testCoroutineRule = TestCoroutineRule()
+
+    private lateinit var viewModel: ChatViewModel
+    private lateinit var fakeRepository: FakeChatRepository
+    private lateinit var getChatHistoryUseCase: GetChatHistoryUseCase
+    private lateinit var sendMessageUseCase: SendMessageUseCase
+
+    @Before
+    fun setUp() {
+        fakeRepository = FakeChatRepository()
+        getChatHistoryUseCase = GetChatHistoryUseCase(fakeRepository)
+        sendMessageUseCase = SendMessageUseCase(fakeRepository)
+        viewModel = ChatViewModel(getChatHistoryUseCase, sendMessageUseCase)
+    }
+
+    @Test
+    fun `navigate to login on unauthorized error`() = runTest {
+        fakeRepository.sendResult = Result.Error(UnauthorizedException())
+
+        viewModel.onEvent(ChatEvent.OnMessageChange("hi"))
+        viewModel.eventFlow.test {
+            viewModel.onEvent(ChatEvent.SendMessage)
+            assertEquals(ChatUiEvent.NavigateToLogin, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- clear auth token for 401/403/404 in `ChatRepositoryImpl`
- add `FakeChatRepository` for tests
- test login navigation on unauthorized error

## Testing
- `gradle test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590db40fa48324a2e0949cd04fa5bf