### PR TITLE
Fix login navigation from chat screen

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
@@ -37,6 +37,7 @@ import com.psy.dear.presentation.chat.ChatUiEvent
 @Composable
 fun ChatScreen(
     navController: NavController,
+    onNavigateToLogin: () -> Unit,
     viewModel: ChatViewModel = hiltViewModel()
 ) {
     val uiState = viewModel.uiState
@@ -45,11 +46,7 @@ fun ChatScreen(
     LaunchedEffect(Unit) {
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
-                ChatUiEvent.NavigateToLogin -> {
-                    navController.navigate("login") {
-                        popUpTo("main_flow") { inclusive = true }
-                    }
-                }
+                ChatUiEvent.NavigateToLogin -> onNavigateToLogin()
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/main/MainScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.*
 import com.psy.dear.presentation.chat.ChatScreen
 import com.psy.dear.presentation.growth.GrowthScreen
@@ -19,7 +20,7 @@ import com.psy.dear.presentation.services.ServicesScreen
 val mainScreens = listOf(Screen.Home, Screen.Chat, Screen.Growth, Screen.Services, Screen.Profile)
 
 @Composable
-fun MainScreen() {
+fun MainScreen(rootNavController: NavHostController) {
     val mainNavController = rememberNavController()
     Scaffold(
         bottomBar = {
@@ -50,7 +51,16 @@ fun MainScreen() {
             modifier = Modifier.padding(innerPadding)
         ) {
             composable(Screen.Home.route) { HomeScreen(navController = mainNavController) }
-            composable(Screen.Chat.route) { ChatScreen(navController = mainNavController) }
+            composable(Screen.Chat.route) {
+                ChatScreen(
+                    navController = mainNavController,
+                    onNavigateToLogin = {
+                        rootNavController.navigate(Screen.Login.route) {
+                            popUpTo(Screen.MainFlow.route) { inclusive = true }
+                        }
+                    }
+                )
+            }
             composable(Screen.Growth.route) { GrowthScreen(navController = mainNavController) }
             composable(Screen.Services.route) { ServicesScreen(navController = mainNavController) }
             composable(Screen.Profile.route) { ProfileScreen(navController = mainNavController) }

--- a/app/src/main/java/com/psy/dear/presentation/navigation/Navigation.kt
+++ b/app/src/main/java/com/psy/dear/presentation/navigation/Navigation.kt
@@ -75,7 +75,7 @@ fun AppNavigation(startDestination: String) {
         }
 
         composable(Screen.MainFlow.route) {
-            MainScreen()
+            MainScreen(navController)
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow ChatScreen to accept a callback for login navigation
- pass the root nav controller to MainScreen
- update Navigation graph to use new MainScreen signature

## Testing
- `pip install httpx`
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685946ab4848832489055baf5f2f272e