### PR TITLE
Add email validation in registration

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import android.util.Patterns
 import kotlinx.coroutines.flow.collectLatest
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -19,6 +20,7 @@ fun RegisterScreen(
     var username by remember { mutableStateOf("") }
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    val isEmailValid by derivedStateOf { Patterns.EMAIL_ADDRESS.matcher(email).matches() }
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
@@ -45,7 +47,11 @@ fun RegisterScreen(
             Spacer(Modifier.height(16.dp))
             OutlinedTextField(value = password, onValueChange = { password = it }, label = { Text("Password") }, modifier = Modifier.fillMaxWidth())
             Spacer(Modifier.height(24.dp))
-            Button(onClick = { viewModel.register(username, email, password) }, modifier = Modifier.fillMaxWidth()) {
+            Button(
+                onClick = { viewModel.register(username, email, password) },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = isEmailValid
+            ) {
                 Text("Register")
             }
             TextButton(onClick = onBack) {

--- a/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterViewModel.kt
@@ -2,6 +2,7 @@ package com.psy.dear.presentation.auth.register
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import android.util.Patterns
 import com.psy.dear.core.Result
 import com.psy.dear.domain.use_case.auth.RegisterUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -23,6 +24,13 @@ class RegisterViewModel @Inject constructor(
     val eventFlow = _eventFlow.asSharedFlow()
 
     fun register(username: String, email: String, password: String) {
+        if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+            viewModelScope.launch {
+                _eventFlow.emit(RegisterEvent.ShowError("Invalid email address"))
+            }
+            return
+        }
+
         viewModelScope.launch {
             when(val result = registerUseCase(username, email, password)) {
                 is Result.Success -> _eventFlow.emit(RegisterEvent.RegisterSuccess)


### PR DESCRIPTION
## Summary
- ensure user-provided email is valid before calling backend
- report an error and keep the Register button disabled when the email format is invalid

## Testing
- `./gradlew test` *(fails: could not find Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68594c56db8c83248241015384a90af6