### PR TITLE
Return 401 on invalid login

### DIFF
--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app import crud, schemas
@@ -27,7 +27,10 @@ def login(
 ):
     user = crud.user.get_by_email(db, email=login_in.email)
     if not user or not verify_password(login_in.password, user.hashed_password):
-        raise HTTPException(status_code=400, detail="Incorrect email or password")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect email or password",
+        )
 
     access_token = create_access_token(user.id)
     return {

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -41,3 +41,20 @@ def test_login_returns_token(client):
     assert "access_token" in data
     assert data["token_type"] == "bearer"
 
+
+def test_login_invalid_credentials(client):
+    client_app, _ = client
+    reg_payload = {
+        "username": "charlie",
+        "email": "charlie@example.com",
+        "password": "secret",
+    }
+    client_app.post("/api/v1/auth/register", json=reg_payload)
+
+    response = client_app.post(
+        "/api/v1/auth/login",
+        json={"email": "charlie@example.com", "password": "wrong"},
+    )
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Incorrect email or password"
+


### PR DESCRIPTION
## Summary
- adjust auth API to use HTTP 401 when credentials are invalid
- test login failure path

## Testing
- `pytest backend/tests/test_auth_api.py::test_login_invalid_credentials -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685964bf49808324ac71caf3e4a184c1