### PR TITLE
Add message flagging support

### DIFF
--- a/app/src/main/java/com/psy/dear/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/psy/dear/data/local/AppDatabase.kt
@@ -12,7 +12,7 @@ import com.psy.dear.data.local.entity.JournalEntity
 
 @Database(
     entities = [JournalEntity::class, ChatMessageEntity::class],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -38,6 +38,12 @@ abstract class AppDatabase : RoomDatabase() {
         val MIGRATION_2_3 = object : Migration(2, 3) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE `chat_messages` ADD COLUMN `emotion` TEXT")
+            }
+        }
+
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `chat_messages` ADD COLUMN `isFlagged` INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/data/local/entity/ChatMessageEntity.kt
+++ b/app/src/main/java/com/psy/dear/data/local/entity/ChatMessageEntity.kt
@@ -10,5 +10,6 @@ data class ChatMessageEntity(
     val role: String, // "user" or "assistant"
     val content: String,
     val emotion: String?,
-    val timestamp: OffsetDateTime
+    val timestamp: OffsetDateTime,
+    val isFlagged: Boolean = false
 )

--- a/app/src/main/java/com/psy/dear/data/mappers/Mappers.kt
+++ b/app/src/main/java/com/psy/dear/data/mappers/Mappers.kt
@@ -47,6 +47,7 @@ fun ChatMessage.toEntity(): ChatMessageEntity {
         role = this.role,
         content = this.content,
         emotion = this.emotion,
-        timestamp = this.timestamp
+        timestamp = this.timestamp,
+        isFlagged = false
     )
 }

--- a/app/src/main/java/com/psy/dear/di/DatabaseModule.kt
+++ b/app/src/main/java/com/psy/dear/di/DatabaseModule.kt
@@ -26,7 +26,8 @@ object DatabaseModule {
         )
             .addMigrations(
                 AppDatabase.MIGRATION_1_2,
-                AppDatabase.MIGRATION_2_3
+                AppDatabase.MIGRATION_2_3,
+                AppDatabase.MIGRATION_3_4
             )
             .build()
     }

--- a/backend/app/db/migrations.py
+++ b/backend/app/db/migrations.py
@@ -1,0 +1,15 @@
+import sqlite3
+from app.core.config import settings
+
+
+def migrate():
+    """Simple migration to add is_flagged column if it doesn't exist."""
+    conn = sqlite3.connect(settings.DATABASE_URL.replace('sqlite:///', ''))
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA table_info(chat_messages)")
+    columns = [row[1] for row in cursor.fetchall()]
+    if 'is_flagged' not in columns:
+        cursor.execute("ALTER TABLE chat_messages ADD COLUMN is_flagged BOOLEAN NOT NULL DEFAULT 0")
+        conn.commit()
+    conn.close()
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from app.db.session import engine
 from app.models import *  # noqa
 from app.db.base_class import Base
+from app.db.migrations import migrate
 
 app = FastAPI(title="Dear Diary API")
 
@@ -12,6 +13,7 @@ app = FastAPI(title="Dear Diary API")
 def on_startup() -> None:
     """Create database tables on startup."""
     Base.metadata.create_all(bind=engine)
+    migrate()
 
 app.include_router(api_router, prefix="/api/v1")
 

--- a/backend/app/models/chat.py
+++ b/backend/app/models/chat.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Enum as SQLAlchemyEnum
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Enum as SQLAlchemyEnum, Boolean
 from sqlalchemy.orm import relationship
 from app.db.base_class import Base
 import datetime
@@ -22,3 +22,4 @@ class ChatMessage(Base):
     ai_technique = Column(String, nullable=True)
     # Optional emotion label for the message
     emotion = Column(String, nullable=True)
+    is_flagged = Column(Boolean, default=False)

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -9,6 +9,7 @@ class ChatMessageBase(BaseModel):
     sender_type: SenderType
     ai_technique: Optional[str] = None
     emotion: Optional[str] = None
+    is_flagged: bool = False
 
 
 # Skema untuk membuat pesan baru (digunakan oleh CRUD)
@@ -26,6 +27,7 @@ class ChatMessageInDBBase(ChatMessageBase):
     id: int
     owner_id: int
     created_at: datetime
+    is_flagged: bool
 
     # Perbaikan untuk warning 'orm_mode'
     model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- add `is_flagged` to chat message model and schemas
- expose new boolean field for Android via `ChatMessageEntity`
- handle SQLite schema migration on backend startup
- add Room migration and database version bump

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859978a84f4832489ec9696a251b1c3