### PR TITLE
Add chat message management

### DIFF
--- a/app/src/main/java/com/psy/dear/data/local/dao/ChatMessageDao.kt
+++ b/app/src/main/java/com/psy/dear/data/local/dao/ChatMessageDao.kt
@@ -14,4 +14,10 @@ interface ChatMessageDao {
 
     @Query("SELECT * FROM chat_messages ORDER BY timestamp ASC")
     fun getAll(): Flow<List<ChatMessageEntity>>
+
+    @Query("UPDATE chat_messages SET isFlagged = :flag WHERE id = :id")
+    suspend fun updateFlagById(id: String, flag: Boolean)
+
+    @Query("DELETE FROM chat_messages WHERE id = :id")
+    suspend fun deleteById(id: String)
 }

--- a/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
+++ b/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
@@ -1,9 +1,7 @@
 package com.psy.dear.data.network.api
 
 import com.psy.dear.data.network.dto.*
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.POST
+import retrofit2.http.*
 
 interface AuthApiService {
     @POST("auth/login")
@@ -22,6 +20,15 @@ interface JournalApiService {
 interface ChatApiService {
     @POST("chat/")
     suspend fun postMessage(@Body request: ChatRequest): ChatResponse
+
+    @DELETE("chat/{id}")
+    suspend fun deleteMessage(@Path("id") id: String)
+
+    @POST("chat/{id}/flag")
+    suspend fun setFlag(
+        @Path("id") id: String,
+        @Body request: FlagRequest
+    )
 }
 
 interface UserApiService {

--- a/app/src/main/java/com/psy/dear/data/network/dto/Dtos.kt
+++ b/app/src/main/java/com/psy/dear/data/network/dto/Dtos.kt
@@ -26,6 +26,10 @@ data class ChatResponse(
     val emotion: String?
 )
 
+data class FlagRequest(
+    @SerializedName("is_flagged") val isFlagged: Boolean
+)
+
 // UserDtos
 data class UserProfileResponse(
     val id: String,

--- a/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
@@ -15,6 +15,7 @@ import com.psy.dear.data.network.dto.ChatRequest
 import com.psy.dear.data.network.dto.CreateJournalRequest
 import com.psy.dear.data.network.dto.LoginRequest
 import com.psy.dear.data.network.dto.RegisterRequest
+import com.psy.dear.data.network.dto.FlagRequest
 import com.psy.dear.domain.model.*
 import com.psy.dear.domain.repository.AuthRepository
 import com.psy.dear.domain.repository.ChatRepository
@@ -137,5 +138,21 @@ class ChatRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             Result.Error(e)
         }
+    }
+
+    override suspend fun deleteMessage(id: String): Result<Unit> = try {
+        api.deleteMessage(id)
+        dao.deleteById(id)
+        Result.Success(Unit)
+    } catch (e: Exception) {
+        Result.Error(e)
+    }
+
+    override suspend fun setFlag(id: String, flagged: Boolean): Result<Unit> = try {
+        api.setFlag(id, FlagRequest(flagged))
+        dao.updateFlagById(id, flagged)
+        Result.Success(Unit)
+    } catch (e: Exception) {
+        Result.Error(e)
     }
 }

--- a/app/src/main/java/com/psy/dear/domain/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/domain/repository/Repositories.kt
@@ -28,4 +28,6 @@ interface UserRepository {
 interface ChatRepository {
     fun getChatHistory(): Flow<List<ChatMessage>>
     suspend fun sendMessage(message: String): Result<Unit>
+    suspend fun deleteMessage(id: String): Result<Unit>
+    suspend fun setFlag(id: String, flagged: Boolean): Result<Unit>
 }

--- a/app/src/test/java/com/psy/dear/data/repository/FakeChatRepository.kt
+++ b/app/src/test/java/com/psy/dear/data/repository/FakeChatRepository.kt
@@ -16,4 +16,8 @@ class FakeChatRepository : ChatRepository {
     override suspend fun sendMessage(message: String): Result<Unit> {
         return sendResult
     }
+
+    override suspend fun deleteMessage(id: String): Result<Unit> = Result.Success(Unit)
+
+    override suspend fun setFlag(id: String, flagged: Boolean): Result<Unit> = Result.Success(Unit)
 }

--- a/backend/app/crud/crud_chat.py
+++ b/backend/app/crud/crud_chat.py
@@ -1,3 +1,4 @@
+from sqlalchemy.orm import Session
 from .base import CRUDBase
 from app.models.chat import ChatMessage
 from app.schemas.chat import ChatMessageCreate, ChatMessageUpdate
@@ -22,5 +23,31 @@ class CRUDChatMessage(CRUDBase[ChatMessage, ChatMessageCreate, ChatMessageUpdate
             .limit(limit)
             .all()
         )
+
+    def remove(self, db: Session, *, id: int, owner_id: int) -> ChatMessage | None:
+        obj = (
+            db.query(ChatMessage)
+            .filter(ChatMessage.id == id, ChatMessage.owner_id == owner_id)
+            .first()
+        )
+        if obj:
+            db.delete(obj)
+            db.commit()
+        return obj
+
+    def set_flag(
+        self, db: Session, *, id: int, owner_id: int, flag: bool
+    ) -> ChatMessage | None:
+        obj = (
+            db.query(ChatMessage)
+            .filter(ChatMessage.id == id, ChatMessage.owner_id == owner_id)
+            .first()
+        )
+        if obj:
+            obj.is_flagged = flag
+            db.add(obj)
+            db.commit()
+            db.refresh(obj)
+        return obj
 
 chat_message = CRUDChatMessage(ChatMessage)


### PR DESCRIPTION
## Summary
- mark chat messages flagged and delete them
- support flagging and deletion via backend CRUD helpers and Retrofit
- expose new repository operations

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_685998ff53808324973e474b306439a5