### PR TITLE
Add chat flag and delete API endpoints

### DIFF
--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -10,6 +10,7 @@ from app.services.emotion_service import EmotionService
 
 router = APIRouter()
 
+
 def get_latest_journal(db: Session, user: models.User) -> str:
     """Return the latest journal content or empty string."""
     # CRUDJournal.get_multi_by_owner now returns entries ordered by
@@ -17,15 +18,16 @@ def get_latest_journal(db: Session, user: models.User) -> str:
     journals = crud.journal.get_multi_by_owner(db, owner_id=user.id, limit=1)
     return journals[0].content if journals else ""
 
+
 @router.post("/", response_model=schemas.chat.ChatMessage)
 async def handle_chat_message(
-        *,
-        db: Session = Depends(dependencies.get_db),
-        chat_in: schemas.chat.ChatRequest,
-        current_user: models.User = Depends(dependencies.get_current_user),
-        planner: PlannerService = Depends(),
-        generator: GeneratorService = Depends(),
-        emotion_service: EmotionService = Depends(),
+    *,
+    db: Session = Depends(dependencies.get_db),
+    chat_in: schemas.chat.ChatRequest,
+    current_user: models.User = Depends(dependencies.get_current_user),
+    planner: PlannerService = Depends(),
+    generator: GeneratorService = Depends(),
+    emotion_service: EmotionService = Depends(),
 ):
     """
     Orkestrasi alur chat Planner/Generator.
@@ -37,7 +39,9 @@ async def handle_chat_message(
         sender_type=SenderType.USER,
         emotion=emotion_label,
     )
-    crud.chat_message.create_with_owner(db, obj_in=user_message_obj, owner_id=current_user.id)
+    crud.chat_message.create_with_owner(
+        db, obj_in=user_message_obj, owner_id=current_user.id
+    )
 
     # 2. Ambil riwayat chat & bangun konteks
     # Load a bit more history to give the Planner and Generator
@@ -78,8 +82,39 @@ async def handle_chat_message(
     ai_message_obj = schemas.chat.ChatMessageCreate(
         content=final_response,
         sender_type=SenderType.AI,
-        ai_technique=conversation_plan.technique.value
+        ai_technique=conversation_plan.technique.value,
     )
-    ai_message_db = crud.chat_message.create_with_owner(db, obj_in=ai_message_obj, owner_id=current_user.id)
+    ai_message_db = crud.chat_message.create_with_owner(
+        db, obj_in=ai_message_obj, owner_id=current_user.id
+    )
 
     return ai_message_db
+
+
+@router.patch("/{id}/flag", response_model=schemas.chat.ChatMessage)
+def update_chat_flag(
+    *,
+    db: Session = Depends(dependencies.get_db),
+    id: int,
+    flag_in: schemas.chat.ChatFlagUpdate,
+    current_user: models.User = Depends(dependencies.get_current_user),
+):
+    message = crud.chat_message.set_flag(
+        db, id=id, owner_id=current_user.id, flag=flag_in.flag
+    )
+    if not message:
+        raise HTTPException(status_code=404, detail="Chat message not found")
+    return message
+
+
+@router.delete("/{id}", response_model=schemas.chat.ChatMessage)
+def delete_chat_message(
+    *,
+    db: Session = Depends(dependencies.get_db),
+    id: int,
+    current_user: models.User = Depends(dependencies.get_current_user),
+):
+    message = crud.chat_message.remove(db, id=id, owner_id=current_user.id)
+    if not message:
+        raise HTTPException(status_code=404, detail="Chat message not found")
+    return message

--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -3,6 +3,7 @@ from typing import Optional
 from datetime import datetime
 from app.models.chat import SenderType
 
+
 # Skema dasar untuk field yang sama di semua varian
 class ChatMessageBase(BaseModel):
     content: str
@@ -20,6 +21,11 @@ class ChatMessageCreate(ChatMessageBase):
 # Skema untuk memperbarui pesan (saat ini tidak digunakan, tapi ada untuk kelengkapan)
 class ChatMessageUpdate(BaseModel):
     pass
+
+
+# Schema for flagging/unflagging a chat message
+class ChatFlagUpdate(BaseModel):
+    flag: bool
 
 
 # Skema untuk properti yang ada di database tetapi tidak selalu dikirim ke klien


### PR DESCRIPTION
## Summary
- add schema for chat message flag updates
- implement flag and delete endpoints for chat
- test flagging and deletion behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599a6ac0bc8324b2e874853b76d7dd