### PR TITLE
Add chat message flag/delete

### DIFF
--- a/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
@@ -148,7 +148,7 @@ class ChatRepositoryImpl @Inject constructor(
         Result.Error(e)
     }
 
-    override suspend fun setFlag(id: String, flagged: Boolean): Result<Unit> = try {
+    override suspend fun flagMessage(id: String, flagged: Boolean): Result<Unit> = try {
         api.setFlag(id, FlagRequest(flagged))
         dao.updateFlagById(id, flagged)
         Result.Success(Unit)

--- a/app/src/main/java/com/psy/dear/domain/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/domain/repository/Repositories.kt
@@ -29,5 +29,5 @@ interface ChatRepository {
     fun getChatHistory(): Flow<List<ChatMessage>>
     suspend fun sendMessage(message: String): Result<Unit>
     suspend fun deleteMessage(id: String): Result<Unit>
-    suspend fun setFlag(id: String, flagged: Boolean): Result<Unit>
+    suspend fun flagMessage(id: String, flagged: Boolean): Result<Unit>
 }

--- a/app/src/main/java/com/psy/dear/domain/use_case/chat/UseCases.kt
+++ b/app/src/main/java/com/psy/dear/domain/use_case/chat/UseCases.kt
@@ -22,3 +22,16 @@ class SendMessageUseCase @Inject constructor(
         return repository.sendMessage(message)
     }
 }
+
+class DeleteMessageUseCase @Inject constructor(
+    private val repository: ChatRepository
+) {
+    suspend operator fun invoke(id: String): Result<Unit> = repository.deleteMessage(id)
+}
+
+class FlagMessageUseCase @Inject constructor(
+    private val repository: ChatRepository
+) {
+    suspend operator fun invoke(id: String, flagged: Boolean): Result<Unit> =
+        repository.flagMessage(id, flagged)
+}

--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -92,7 +94,11 @@ fun ChatScreen(
                     .padding(horizontal = 8.dp)
             ) {
                 items(uiState.messages) { message ->
-                    ChatMessageItem(message = message)
+                    ChatMessageItem(
+                        message = message,
+                        onDelete = { viewModel.onEvent(ChatEvent.DeleteMessage(message.id)) },
+                        onFlag = { flag -> viewModel.onEvent(ChatEvent.FlagMessage(message.id, flag)) }
+                    )
                 }
             }
         }
@@ -142,7 +148,11 @@ fun ChatInputBar(
 }
 
 @Composable
-fun ChatMessageItem(message: ChatMessage) {
+fun ChatMessageItem(
+    message: ChatMessage,
+    onDelete: () -> Unit,
+    onFlag: (Boolean) -> Unit
+) {
     // Tampilan sederhana untuk item chat, bisa dikembangkan lebih lanjut
     // dengan gelembung chat (chat bubble)
     // Gunakan peran ("role") pesan untuk menentukan perataan
@@ -153,11 +163,20 @@ fun ChatMessageItem(message: ChatMessage) {
             .padding(vertical = 4.dp),
         contentAlignment = alignment
     ) {
-        Text(
-            text = message.content,
-            modifier = Modifier
-                .padding(8.dp)
-        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = message.content,
+                modifier = Modifier
+                    .padding(8.dp)
+                    .weight(1f)
+            )
+            IconButton(onClick = { onFlag(true) }) {
+                Icon(Icons.Default.Flag, contentDescription = "Flag")
+            }
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Default.Delete, contentDescription = "Delete")
+            }
+        }
     }
 }
 

--- a/app/src/test/java/com/psy/dear/data/repository/FakeChatRepository.kt
+++ b/app/src/test/java/com/psy/dear/data/repository/FakeChatRepository.kt
@@ -19,5 +19,5 @@ class FakeChatRepository : ChatRepository {
 
     override suspend fun deleteMessage(id: String): Result<Unit> = Result.Success(Unit)
 
-    override suspend fun setFlag(id: String, flagged: Boolean): Result<Unit> = Result.Success(Unit)
+    override suspend fun flagMessage(id: String, flagged: Boolean): Result<Unit> = Result.Success(Unit)
 }

--- a/app/src/test/java/com/psy/dear/presentation/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/dear/presentation/chat/ChatViewModelTest.kt
@@ -6,6 +6,8 @@ import com.psy.dear.core.UnauthorizedException
 import com.psy.dear.data.repository.FakeChatRepository
 import com.psy.dear.domain.use_case.chat.GetChatHistoryUseCase
 import com.psy.dear.domain.use_case.chat.SendMessageUseCase
+import com.psy.dear.domain.use_case.chat.DeleteMessageUseCase
+import com.psy.dear.domain.use_case.chat.FlagMessageUseCase
 import com.psy.dear.util.TestCoroutineRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -24,13 +26,22 @@ class ChatViewModelTest {
     private lateinit var fakeRepository: FakeChatRepository
     private lateinit var getChatHistoryUseCase: GetChatHistoryUseCase
     private lateinit var sendMessageUseCase: SendMessageUseCase
+    private lateinit var deleteMessageUseCase: DeleteMessageUseCase
+    private lateinit var flagMessageUseCase: FlagMessageUseCase
 
     @Before
     fun setUp() {
         fakeRepository = FakeChatRepository()
         getChatHistoryUseCase = GetChatHistoryUseCase(fakeRepository)
         sendMessageUseCase = SendMessageUseCase(fakeRepository)
-        viewModel = ChatViewModel(getChatHistoryUseCase, sendMessageUseCase)
+        deleteMessageUseCase = DeleteMessageUseCase(fakeRepository)
+        flagMessageUseCase = FlagMessageUseCase(fakeRepository)
+        viewModel = ChatViewModel(
+            getChatHistoryUseCase,
+            sendMessageUseCase,
+            deleteMessageUseCase,
+            flagMessageUseCase
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add flagMessage API to repository and implementation
- create use cases for deleting and flagging chat messages
- wire ChatViewModel and ChatScreen to use the new actions
- adjust tests and fake repository

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6859a01b5728832490db5404d1dee70d