### PR TITLE
Remove flag message UI features

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -117,8 +116,7 @@ fun ChatScreen(
                             }
                         },
                         onLongPress = { viewModel.onEvent(ChatEvent.EnterSelection(message.id)) },
-                        onDelete = { viewModel.onEvent(ChatEvent.DeleteMessage(message.id)) },
-                        onFlag = { flag -> viewModel.onEvent(ChatEvent.FlagMessage(message.id, flag)) }
+                        onDelete = { viewModel.onEvent(ChatEvent.DeleteMessage(message.id)) }
                     )
                 }
             }
@@ -203,8 +201,7 @@ fun ChatMessageItem(
     selectionMode: Boolean,
     onClick: () -> Unit,
     onLongPress: () -> Unit,
-    onDelete: () -> Unit,
-    onFlag: (Boolean) -> Unit
+    onDelete: () -> Unit
 ) {
     // Tampilan sederhana untuk item chat, bisa dikembangkan lebih lanjut
     // dengan gelembung chat (chat bubble)
@@ -229,9 +226,6 @@ fun ChatMessageItem(
                     .weight(1f)
             )
             if (!selectionMode) {
-                IconButton(onClick = { onFlag(true) }) {
-                    Icon(Icons.Default.Flag, contentDescription = "Flag")
-                }
                 IconButton(onClick = onDelete) {
                     Icon(Icons.Default.Delete, contentDescription = "Delete")
                 }

--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatViewModel.kt
@@ -12,7 +12,6 @@ import com.psy.dear.core.UnauthorizedException
 import com.psy.dear.domain.use_case.chat.GetChatHistoryUseCase
 import com.psy.dear.domain.use_case.chat.SendMessageUseCase
 import com.psy.dear.domain.use_case.chat.DeleteMessageUseCase
-import com.psy.dear.domain.use_case.chat.FlagMessageUseCase
 import com.psy.dear.domain.model.ChatMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -27,8 +26,7 @@ import javax.inject.Inject
 class ChatViewModel @Inject constructor(
     private val getChatHistoryUseCase: GetChatHistoryUseCase,
     private val sendMessageUseCase: SendMessageUseCase,
-    private val deleteMessageUseCase: DeleteMessageUseCase,
-    private val flagMessageUseCase: FlagMessageUseCase
+    private val deleteMessageUseCase: DeleteMessageUseCase
 ) : ViewModel() {
 
     var uiState by mutableStateOf(ChatUiState())
@@ -55,9 +53,6 @@ class ChatViewModel @Inject constructor(
             }
             is ChatEvent.DeleteMessage -> {
                 deleteMessage(event.id)
-            }
-            is ChatEvent.FlagMessage -> {
-                flagMessage(event.id, event.flagged)
             }
             is ChatEvent.EnterSelection -> {
                 enterSelection(event.id)
@@ -121,13 +116,6 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    private fun flagMessage(id: String, flagged: Boolean) {
-        viewModelScope.launch {
-            flagMessageUseCase(id, flagged)
-            uiState = uiState.copy(messages = getChatHistoryUseCase().first())
-        }
-    }
-
     private fun enterSelection(id: String) {
         uiState = uiState.copy(
             selectionMode = true,
@@ -174,7 +162,6 @@ sealed class ChatEvent {
     data class OnMessageChange(val message: String) : ChatEvent()
     object SendMessage : ChatEvent()
     data class DeleteMessage(val id: String) : ChatEvent()
-    data class FlagMessage(val id: String, val flagged: Boolean) : ChatEvent()
     data class EnterSelection(val id: String) : ChatEvent()
     data class ToggleSelection(val id: String) : ChatEvent()
     object DeleteSelected : ChatEvent()

--- a/app/src/test/java/com/psy/dear/presentation/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/dear/presentation/chat/ChatViewModelTest.kt
@@ -7,7 +7,6 @@ import com.psy.dear.data.repository.FakeChatRepository
 import com.psy.dear.domain.use_case.chat.GetChatHistoryUseCase
 import com.psy.dear.domain.use_case.chat.SendMessageUseCase
 import com.psy.dear.domain.use_case.chat.DeleteMessageUseCase
-import com.psy.dear.domain.use_case.chat.FlagMessageUseCase
 import com.psy.dear.util.TestCoroutineRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -27,7 +26,6 @@ class ChatViewModelTest {
     private lateinit var getChatHistoryUseCase: GetChatHistoryUseCase
     private lateinit var sendMessageUseCase: SendMessageUseCase
     private lateinit var deleteMessageUseCase: DeleteMessageUseCase
-    private lateinit var flagMessageUseCase: FlagMessageUseCase
 
     @Before
     fun setUp() {
@@ -35,12 +33,10 @@ class ChatViewModelTest {
         getChatHistoryUseCase = GetChatHistoryUseCase(fakeRepository)
         sendMessageUseCase = SendMessageUseCase(fakeRepository)
         deleteMessageUseCase = DeleteMessageUseCase(fakeRepository)
-        flagMessageUseCase = FlagMessageUseCase(fakeRepository)
         viewModel = ChatViewModel(
             getChatHistoryUseCase,
             sendMessageUseCase,
-            deleteMessageUseCase,
-            flagMessageUseCase
+            deleteMessageUseCase
         )
     }
 


### PR DESCRIPTION
## Summary
- remove flag icon button from `ChatMessageItem`
- drop `ChatEvent.FlagMessage` and use-case from `ChatViewModel`
- adjust test setup for removed dependency

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b865fbc88324891fbf44a076925c