### PR TITLE
Add selection tests for ChatViewModel

### DIFF
--- a/app/src/test/java/com/psy/dear/data/repository/FakeChatRepository.kt
+++ b/app/src/test/java/com/psy/dear/data/repository/FakeChatRepository.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 class FakeChatRepository : ChatRepository {
     private val messagesFlow = MutableStateFlow<List<ChatMessage>>(emptyList())
     var sendResult: Result<Unit> = Result.Success(Unit)
+    val deletedIds = mutableListOf<String>()
 
     override fun getChatHistory(): Flow<List<ChatMessage>> = messagesFlow.asStateFlow()
 
@@ -17,7 +18,10 @@ class FakeChatRepository : ChatRepository {
         return sendResult
     }
 
-    override suspend fun deleteMessage(id: String): Result<Unit> = Result.Success(Unit)
+    override suspend fun deleteMessage(id: String): Result<Unit> {
+        deletedIds.add(id)
+        return Result.Success(Unit)
+    }
 
     override suspend fun flagMessage(id: String, flagged: Boolean): Result<Unit> = Result.Success(Unit)
 }

--- a/app/src/test/java/com/psy/dear/presentation/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/psy/dear/presentation/chat/ChatViewModelTest.kt
@@ -51,4 +51,41 @@ class ChatViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    @Test
+    fun `enter selection activates mode and stores id`() = runTest {
+        viewModel.onEvent(ChatEvent.EnterSelection("1"))
+
+        assertEquals(true, viewModel.uiState.selectionMode)
+        assertEquals(setOf("1"), viewModel.uiState.selectedIds)
+    }
+
+    @Test
+    fun `toggle selection adds and removes ids`() = runTest {
+        viewModel.onEvent(ChatEvent.EnterSelection("1"))
+
+        viewModel.onEvent(ChatEvent.ToggleSelection("2"))
+        assertEquals(setOf("1", "2"), viewModel.uiState.selectedIds)
+        assertEquals(true, viewModel.uiState.selectionMode)
+
+        viewModel.onEvent(ChatEvent.ToggleSelection("1"))
+        assertEquals(setOf("2"), viewModel.uiState.selectedIds)
+        assertEquals(true, viewModel.uiState.selectionMode)
+
+        viewModel.onEvent(ChatEvent.ToggleSelection("2"))
+        assertEquals(emptySet(), viewModel.uiState.selectedIds)
+        assertEquals(false, viewModel.uiState.selectionMode)
+    }
+
+    @Test
+    fun `delete selected removes messages and clears selection`() = runTest {
+        viewModel.onEvent(ChatEvent.EnterSelection("1"))
+        viewModel.onEvent(ChatEvent.ToggleSelection("2"))
+
+        viewModel.onEvent(ChatEvent.DeleteSelected)
+
+        assertEquals(listOf("1", "2"), fakeRepository.deletedIds)
+        assertEquals(false, viewModel.uiState.selectionMode)
+        assertEquals(emptySet(), viewModel.uiState.selectedIds)
+    }
 }


### PR DESCRIPTION
## Summary
- update `FakeChatRepository` to record deletes
- extend `ChatViewModelTest` with selection and deletion tests

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b9e622f083248af891ffd5318e07