### PR TITLE
Remove single message delete from chat

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
@@ -115,8 +115,7 @@ fun ChatScreen(
                                 viewModel.onEvent(ChatEvent.ToggleSelection(message.id))
                             }
                         },
-                        onLongPress = { viewModel.onEvent(ChatEvent.EnterSelection(message.id)) },
-                        onDelete = { viewModel.onEvent(ChatEvent.DeleteMessage(message.id)) }
+                        onLongPress = { viewModel.onEvent(ChatEvent.EnterSelection(message.id)) }
                     )
                 }
             }
@@ -200,8 +199,7 @@ fun ChatMessageItem(
     selected: Boolean,
     selectionMode: Boolean,
     onClick: () -> Unit,
-    onLongPress: () -> Unit,
-    onDelete: () -> Unit
+    onLongPress: () -> Unit
 ) {
     // Tampilan sederhana untuk item chat, bisa dikembangkan lebih lanjut
     // dengan gelembung chat (chat bubble)
@@ -225,11 +223,6 @@ fun ChatMessageItem(
                     .padding(8.dp)
                     .weight(1f)
             )
-            if (!selectionMode) {
-                IconButton(onClick = onDelete) {
-                    Icon(Icons.Default.Delete, contentDescription = "Delete")
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatViewModel.kt
@@ -51,9 +51,6 @@ class ChatViewModel @Inject constructor(
             is ChatEvent.SendMessage -> {
                 sendMessage()
             }
-            is ChatEvent.DeleteMessage -> {
-                deleteMessage(event.id)
-            }
             is ChatEvent.EnterSelection -> {
                 enterSelection(event.id)
             }
@@ -109,13 +106,6 @@ class ChatViewModel @Inject constructor(
         }
     }
 
-    private fun deleteMessage(id: String) {
-        viewModelScope.launch {
-            deleteMessageUseCase(id)
-            uiState = uiState.copy(messages = getChatHistoryUseCase().first())
-        }
-    }
-
     private fun enterSelection(id: String) {
         uiState = uiState.copy(
             selectionMode = true,
@@ -161,7 +151,6 @@ data class ChatUiState(
 sealed class ChatEvent {
     data class OnMessageChange(val message: String) : ChatEvent()
     object SendMessage : ChatEvent()
-    data class DeleteMessage(val id: String) : ChatEvent()
     data class EnterSelection(val id: String) : ChatEvent()
     data class ToggleSelection(val id: String) : ChatEvent()
     object DeleteSelected : ChatEvent()


### PR DESCRIPTION
## Summary
- drop single message delete functionality in `ChatMessageItem`
- remove `DeleteMessage` event handling

## Testing
- `gradle test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c2fb52b08324b7bcbf9db5bd5cc9