### PR TITLE
Remove API call when deleting messages

### DIFF
--- a/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
@@ -141,7 +141,6 @@ class ChatRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteMessage(id: String): Result<Unit> = try {
-        api.deleteMessage(id)
         dao.deleteById(id)
         Result.Success(Unit)
     } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- delete chat messages using local DB only

## Testing
- `gradle test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c53462448324b3e5abf85d633929