### PR TITLE
Improve chat bubble visuals

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatBubbleTail.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatBubbleTail.kt
@@ -1,0 +1,34 @@
+package com.psy.dear.presentation.chat
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+
+/**
+ * Small triangular tail used for chat message bubbles.
+ * Flipped horizontally when [isUser] is true so the tail can
+ * appear on either the left or right side of the bubble.
+ */
+@Composable
+fun ChatBubbleTail(color: Color, isUser: Boolean) {
+    Canvas(
+        modifier = Modifier
+            .size(width = 8.dp, height = 10.dp)
+            .graphicsLayer { if (isUser) scaleX = -1f }
+    ) {
+        val path = Path().apply {
+            moveTo(0f, 0f)
+            lineTo(size.width, size.height / 2)
+            lineTo(0f, size.height)
+            close()
+        }
+        drawPath(path = path, color = color, style = Fill)
+    }
+}
+

--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.psy.dear.presentation.chat.ChatBubbleTail
 import androidx.navigation.NavController
 import com.psy.dear.domain.model.ChatMessage
 import com.psy.dear.ui.theme.ChatAppBar
@@ -208,8 +209,7 @@ fun ChatMessageItem(
     onDelete: () -> Unit
 ) {
     val isUser = message.role == "user"
-    val alignment = if (isUser) Alignment.CenterEnd else Alignment.CenterStart
-    Box(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .combinedClickable(onClick = onClick, onLongClick = onLongPress)
@@ -218,14 +218,17 @@ fun ChatMessageItem(
                 else Color.Transparent
             )
             .padding(vertical = 4.dp),
-        contentAlignment = alignment
+        horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
+        verticalAlignment = Alignment.Bottom
     ) {
+        if (!isUser) ChatBubbleTail(color = OtherBubble, isUser = false)
         Surface(
             color = if (isUser) UserBubble else OtherBubble,
-            shape = RoundedCornerShape(8.dp)
+            shape = RoundedCornerShape(16.dp),
+            shadowElevation = 2.dp
         ) {
             Column(
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
                 horizontalAlignment = if (isUser) Alignment.End else Alignment.Start
             ) {
                 Text(
@@ -241,6 +244,7 @@ fun ChatMessageItem(
                 )
             }
         }
+        if (isUser) ChatBubbleTail(color = UserBubble, isUser = true)
     }
 }
 


### PR DESCRIPTION
## Summary
- add ChatBubbleTail composable for bubble tail triangle
- update ChatMessageItem to use new tail and larger rounded corners
- apply subtle shadow and adjust padding

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6859cce9c4fc8324941c60df1701d94e