### PR TITLE
Improve chat input styling

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
@@ -167,13 +167,19 @@ fun ChatInputBar(
             .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        OutlinedTextField(
+        TextField(
             value = text,
             onValueChange = onTextChange,
             modifier = Modifier.weight(1f),
-            placeholder = { Text("Ketik pesanmu...") },
+            placeholder = { Text("Type a message") },
             enabled = !isSending,
-            maxLines = 5
+            maxLines = 5,
+            shape = RoundedCornerShape(24.dp),
+            colors = TextFieldDefaults.textFieldColors(
+                containerColor = Color.White,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+            )
         )
         Spacer(modifier = Modifier.width(8.dp))
 


### PR DESCRIPTION
## Summary
- apply new style to the message text field in ChatInputBar
  - rounded corners, white background and no indicators
  - updated placeholder text to "Type a message"

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6859ce5aa23c8324a938d7ccb4ec5b48