### PR TITLE
Fix collapsing chat messages

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
@@ -239,8 +239,7 @@ fun ChatMessageItem(
             ) {
                 Text(
                     text = message.content,
-                    color = Color.Black,
-                    modifier = Modifier.weight(1f, false)
+                    color = Color.Black
                 )
                 Text(
                     text = message.timestamp.format(DateTimeFormatter.ofPattern("HH:mm")),


### PR DESCRIPTION
## Summary
- ensure chat message content is visible by removing weight from `Text`

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `pytest backend/tests` *(fails: 2 failed, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6859e9934f248324b33ca9f70579f770