### PR TITLE
Add basic UI workflow tests

### DIFF
--- a/app/src/androidTest/java/com/psy/dear/di/TestAppModule.kt
+++ b/app/src/androidTest/java/com/psy/dear/di/TestAppModule.kt
@@ -1,7 +1,16 @@
 package com.psy.dear.di
 
+import com.psy.dear.core.Result
 import com.psy.dear.data.repository.*
+import com.psy.dear.domain.model.*
 import com.psy.dear.domain.repository.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import java.time.OffsetDateTime
+import java.util.UUID
+import javax.inject.Inject
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.components.SingletonComponent
@@ -24,21 +33,110 @@ abstract class TestAppModule {
     @Binds
     @Singleton
     abstract fun bindFakeJournalRepository(impl: FakeJournalRepository): JournalRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindFakeChatRepository(impl: FakeChatRepository): ChatRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindFakeUserRepository(impl: FakeUserRepository): UserRepository
 }
 
 // Implementasi Fake untuk UI Test (perlu dibuat di sini karena visibility)
 @Singleton
 class FakeAuthRepository @Inject constructor() : AuthRepository {
-    private var _isLoggedIn = false
-    override val isLoggedIn: Flow<Boolean> = flowOf(_isLoggedIn)
+    private val loggedIn = MutableStateFlow(false)
+    override val isLoggedIn: Flow<Boolean> = loggedIn.asStateFlow()
+
     override suspend fun login(email: String, password: String): Result<Unit> {
-        _isLoggedIn = true
+        loggedIn.value = true
         return Result.Success(Unit)
     }
-    // Implementasi lainnya...
+
+    override suspend fun register(
+        username: String,
+        email: String,
+        password: String
+    ): Result<Unit> {
+        loggedIn.value = true
+        return Result.Success(Unit)
+    }
+
+    override suspend fun logout() {
+        loggedIn.value = false
+    }
 }
 
 @Singleton
 class FakeJournalRepository @Inject constructor() : JournalRepository {
-    // Implementasi fake yang relevan untuk UI test
+    private val journals = mutableListOf<Journal>()
+    private val flow = MutableStateFlow<List<Journal>>(emptyList())
+
+    override fun getJournals(): Flow<List<Journal>> = flow.asStateFlow()
+
+    override fun getJournalById(id: String): Flow<Journal?> =
+        flow.asStateFlow().map { list -> list.find { it.id == id } }
+
+    override suspend fun syncJournals(): Result<Unit> = Result.Success(Unit)
+
+    override suspend fun createJournal(
+        title: String,
+        content: String,
+        mood: String
+    ): Result<Unit> {
+        val journal = Journal(UUID.randomUUID().toString(), title, content, mood, OffsetDateTime.now())
+        journals.add(journal)
+        flow.value = journals
+        return Result.Success(Unit)
+    }
+
+    override suspend fun updateJournal(
+        id: String,
+        title: String,
+        content: String,
+        mood: String
+    ): Result<Unit> {
+        return Result.Success(Unit)
+    }
+
+    override suspend fun deleteJournal(id: String): Result<Unit> {
+        journals.removeAll { it.id == id }
+        flow.value = journals
+        return Result.Success(Unit)
+    }
+
+    override suspend fun getGrowthStatistics(): Result<GrowthStatistics> =
+        Result.Success(GrowthStatistics(journals.size, "-", 0.0))
+}
+
+@Singleton
+class FakeChatRepository @Inject constructor() : ChatRepository {
+    private val messages = mutableListOf<ChatMessage>()
+    private val flow = MutableStateFlow<List<ChatMessage>>(emptyList())
+
+    override fun getChatHistory(): Flow<List<ChatMessage>> = flow.asStateFlow()
+
+    override suspend fun sendMessage(message: String): Result<Unit> {
+        val userMsg = ChatMessage(UUID.randomUUID().toString(), "user", message, null, OffsetDateTime.now())
+        val reply = ChatMessage(UUID.randomUUID().toString(), "assistant", "reply:$message", null, OffsetDateTime.now())
+        messages.add(userMsg)
+        messages.add(reply)
+        flow.value = messages
+        return Result.Success(Unit)
+    }
+
+    override suspend fun deleteMessage(id: String): Result<Unit> {
+        messages.removeAll { it.id == id }
+        flow.value = messages
+        return Result.Success(Unit)
+    }
+
+    override suspend fun flagMessage(id: String, flagged: Boolean): Result<Unit> = Result.Success(Unit)
+}
+
+@Singleton
+class FakeUserRepository @Inject constructor() : UserRepository {
+    override suspend fun getProfile(): Result<User> =
+        Result.Success(User("1", "Test", "test@example.com"))
 }

--- a/app/src/androidTest/java/com/psy/dear/workflow/ChatWorkflowTest.kt
+++ b/app/src/androidTest/java/com/psy/dear/workflow/ChatWorkflowTest.kt
@@ -1,0 +1,40 @@
+package com.psy.dear.workflow
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.assertIsDisplayed
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Rule
+import org.junit.Test
+import com.psy.dear.MainActivity
+
+@HiltAndroidTest
+class ChatWorkflowTest {
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun sendMessageDisplaysInChat() {
+        hiltRule.inject()
+
+        // Login first
+        composeRule.onNodeWithText("Mulai Sekarang").performClick()
+        composeRule.onNodeWithText("Email").performTextInput("test@example.com")
+        composeRule.onNodeWithText("Password").performTextInput("password")
+        composeRule.onNodeWithText("Login").performClick()
+
+        // Navigate to chat screen
+        composeRule.onNodeWithText("Chat").performClick()
+        composeRule.onNodeWithText("Type a message").performTextInput("Hello")
+        composeRule.onNodeWithContentDescription("Send Message").performClick()
+
+        composeRule.onNodeWithText("Hello").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/psy/dear/workflow/JournalCreationWorkflowTest.kt
+++ b/app/src/androidTest/java/com/psy/dear/workflow/JournalCreationWorkflowTest.kt
@@ -1,0 +1,42 @@
+package com.psy.dear.workflow
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.assertIsDisplayed
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Rule
+import org.junit.Test
+import com.psy.dear.MainActivity
+
+@HiltAndroidTest
+class JournalCreationWorkflowTest {
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun createJournalShowsInList() {
+        hiltRule.inject()
+
+        // Go through login first
+        composeRule.onNodeWithText("Mulai Sekarang").performClick()
+        composeRule.onNodeWithText("Email").performTextInput("test@example.com")
+        composeRule.onNodeWithText("Password").performTextInput("password")
+        composeRule.onNodeWithText("Login").performClick()
+
+        // Open editor
+        composeRule.onNodeWithContentDescription("Entri Baru").performClick()
+        composeRule.onNodeWithText("Judul").performTextInput("Test Entry")
+        composeRule.onNodeWithText("Apa yang kamu rasakan?").performTextInput("Isi")
+        composeRule.onNodeWithText("Simpan").performClick()
+
+        // Verify entry displayed on home
+        composeRule.onNodeWithText("Test Entry").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/psy/dear/workflow/LoginWorkflowTest.kt
+++ b/app/src/androidTest/java/com/psy/dear/workflow/LoginWorkflowTest.kt
@@ -1,0 +1,37 @@
+package com.psy.dear.workflow
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.assertIsDisplayed
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Rule
+import org.junit.Test
+import com.psy.dear.MainActivity
+
+@HiltAndroidTest
+class LoginWorkflowTest {
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun loginNavigatesToHome() {
+        hiltRule.inject()
+
+        // Complete onboarding
+        composeRule.onNodeWithText("Mulai Sekarang").performClick()
+
+        // Enter credentials on login screen
+        composeRule.onNodeWithText("Email").performTextInput("test@example.com")
+        composeRule.onNodeWithText("Password").performTextInput("password")
+        composeRule.onNodeWithText("Login").performClick()
+
+        // Verify home screen shown
+        composeRule.onNodeWithText("Beranda").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## Summary
- add Hilt fake repositories for androidTest
- create login, journal creation and chat UI workflow tests using Compose

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6859f22419448324aff27d707f77ac76