### PR TITLE
Add error mapping and UiText

### DIFF
--- a/app/src/main/java/com/psy/dear/core/ErrorMapper.kt
+++ b/app/src/main/java/com/psy/dear/core/ErrorMapper.kt
@@ -1,0 +1,22 @@
+package com.psy.dear.core
+
+import com.psy.dear.R
+import retrofit2.HttpException
+import java.io.IOException
+
+object ErrorMapper {
+    fun map(throwable: Throwable?): Int {
+        val error = throwable ?: return R.string.error_unknown
+        return when (error) {
+            is UnauthorizedException -> R.string.error_unauthorized
+            is IOException -> R.string.error_network
+            is HttpException -> {
+                when (error.code()) {
+                    401, 403, 404 -> R.string.error_unauthorized
+                    else -> R.string.error_unknown
+                }
+            }
+            else -> R.string.error_unknown
+        }
+    }
+}

--- a/app/src/main/java/com/psy/dear/core/UiText.kt
+++ b/app/src/main/java/com/psy/dear/core/UiText.kt
@@ -1,0 +1,16 @@
+package com.psy.dear.core
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+
+sealed class UiText {
+    data class DynamicString(val value: String) : UiText()
+    data class StringResource(@StringRes val resId: Int) : UiText()
+}
+
+@Composable
+fun UiText.asString(): String = when (this) {
+    is UiText.DynamicString -> value
+    is UiText.StringResource -> stringResource(id = resId)
+}

--- a/app/src/main/java/com/psy/dear/presentation/auth/login/LoginScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/auth/login/LoginScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.psy.dear.R
 import kotlinx.coroutines.flow.collectLatest
+import com.psy.dear.core.asString
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -26,7 +27,7 @@ fun LoginScreen(
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 is LoginEvent.LoginSuccess -> onLoginSuccess()
-                is LoginEvent.ShowError -> snackbarHostState.showSnackbar(event.message)
+                is LoginEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString())
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/presentation/auth/login/LoginViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/auth/login/LoginViewModel.kt
@@ -3,6 +3,8 @@ package com.psy.dear.presentation.auth.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.psy.dear.core.Result
+import com.psy.dear.core.ErrorMapper
+import com.psy.dear.core.UiText
 import com.psy.dear.domain.use_case.auth.LoginUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -12,7 +14,7 @@ import javax.inject.Inject
 
 sealed class LoginEvent {
     object LoginSuccess : LoginEvent()
-    data class ShowError(val message: String) : LoginEvent()
+    data class ShowError(val message: UiText) : LoginEvent()
 }
 
 @HiltViewModel
@@ -26,7 +28,7 @@ class LoginViewModel @Inject constructor(
         viewModelScope.launch {
             when(val result = loginUseCase(email, password)) {
                 is Result.Success -> _eventFlow.emit(LoginEvent.LoginSuccess)
-                is Result.Error -> _eventFlow.emit(LoginEvent.ShowError(result.exception?.message ?: "Login failed"))
+                is Result.Error -> _eventFlow.emit(LoginEvent.ShowError(UiText.StringResource(ErrorMapper.map(result.exception))))
                 else -> {}
             }
         }

--- a/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import android.util.Patterns
 import kotlinx.coroutines.flow.collectLatest
+import com.psy.dear.core.asString
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -27,7 +28,7 @@ fun RegisterScreen(
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 is RegisterEvent.RegisterSuccess -> onRegisterSuccess()
-                is RegisterEvent.ShowError -> snackbarHostState.showSnackbar(event.message)
+                is RegisterEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString())
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import android.util.Patterns
 import com.psy.dear.core.Result
+import com.psy.dear.core.ErrorMapper
+import com.psy.dear.core.UiText
 import com.psy.dear.domain.use_case.auth.RegisterUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -13,7 +15,7 @@ import javax.inject.Inject
 
 sealed class RegisterEvent {
     object RegisterSuccess : RegisterEvent()
-    data class ShowError(val message: String) : RegisterEvent()
+    data class ShowError(val message: UiText) : RegisterEvent()
 }
 
 @HiltViewModel
@@ -26,7 +28,7 @@ class RegisterViewModel @Inject constructor(
     fun register(username: String, email: String, password: String) {
         if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
             viewModelScope.launch {
-                _eventFlow.emit(RegisterEvent.ShowError("Invalid email address"))
+                _eventFlow.emit(RegisterEvent.ShowError(UiText.DynamicString("Invalid email address")))
             }
             return
         }
@@ -34,7 +36,7 @@ class RegisterViewModel @Inject constructor(
         viewModelScope.launch {
             when(val result = registerUseCase(username, email, password)) {
                 is Result.Success -> _eventFlow.emit(RegisterEvent.RegisterSuccess)
-                is Result.Error -> _eventFlow.emit(RegisterEvent.ShowError(result.exception?.message ?: "Registration failed"))
+                is Result.Error -> _eventFlow.emit(RegisterEvent.ShowError(UiText.StringResource(ErrorMapper.map(result.exception))))
                 else -> {}
             }
         }

--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
@@ -32,6 +32,7 @@ import com.psy.dear.ui.theme.ChatBackground
 import com.psy.dear.ui.theme.OtherBubble
 import com.psy.dear.ui.theme.UserBubble
 import com.psy.dear.ui.theme.IconInactive
+import com.psy.dear.core.asString
 import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.flow.collectLatest
 
@@ -85,7 +86,7 @@ fun ChatScreen(
         ) {
             if (uiState.error != null) {
                 Text(
-                    text = uiState.error,
+                    text = uiState.error.asString(),
                     color = MaterialTheme.colorScheme.error,
                     textAlign = TextAlign.Center,
                     modifier = Modifier

--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatViewModel.kt
@@ -9,6 +9,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.psy.dear.core.Result
 import com.psy.dear.core.UnauthorizedException
+import com.psy.dear.core.ErrorMapper
+import com.psy.dear.core.UiText
 import com.psy.dear.domain.use_case.chat.GetChatHistoryUseCase
 import com.psy.dear.domain.use_case.chat.SendMessageUseCase
 import com.psy.dear.domain.use_case.chat.DeleteMessageUseCase
@@ -88,7 +90,7 @@ class ChatViewModel @Inject constructor(
                         if (result.exception is UnauthorizedException) {
                             _eventFlow.emit(ChatUiEvent.NavigateToLogin)
                         }
-                        uiState = uiState.copy(error = result.exception?.message ?: "An unknown error occurred")
+                        uiState = uiState.copy(error = UiText.StringResource(ErrorMapper.map(result.exception)))
                     }
                     is Result.Loading -> {}
                 }
@@ -145,7 +147,7 @@ data class ChatUiState(
     val messages: List<ChatMessage> = emptyList(),
     val currentMessage: String = "",
     val isSending: Boolean = false,
-    val error: String? = null,
+    val error: UiText? = null,
     val selectionMode: Boolean = false,
     val selectedIds: Set<String> = emptySet()
 )

--- a/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.psy.dear.domain.model.GrowthStatistics
+import com.psy.dear.core.asString
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -26,7 +27,7 @@ fun GrowthScreen(
         Box(modifier = Modifier.fillMaxSize().padding(padding)) {
             when {
                 state.isLoading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                state.error != null -> Text(text = state.error!!, modifier = Modifier.align(Alignment.Center))
+                state.error != null -> Text(text = state.error.asString(), modifier = Modifier.align(Alignment.Center))
                 state.stats != null -> StatisticsContent(stats = state.stats!!)
             }
         }

--- a/app/src/main/java/com/psy/dear/presentation/growth/GrowthViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/growth/GrowthViewModel.kt
@@ -3,6 +3,8 @@ package com.psy.dear.presentation.growth
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.psy.dear.core.Result
+import com.psy.dear.core.ErrorMapper
+import com.psy.dear.core.UiText
 import com.psy.dear.domain.model.GrowthStatistics
 import com.psy.dear.domain.use_case.journal.GetGrowthStatisticsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,7 +16,7 @@ import javax.inject.Inject
 data class GrowthState(
     val stats: GrowthStatistics? = null,
     val isLoading: Boolean = false,
-    val error: String? = null
+    val error: UiText? = null
 )
 
 @HiltViewModel
@@ -34,7 +36,7 @@ class GrowthViewModel @Inject constructor(
             _state.value = GrowthState(isLoading = true)
             when (val result = getGrowthStatisticsUseCase()) {
                 is Result.Success -> _state.value = GrowthState(stats = result.data)
-                is Result.Error -> _state.value = GrowthState(error = result.exception?.message)
+                is Result.Error -> _state.value = GrowthState(error = UiText.StringResource(ErrorMapper.map(result.exception)))
                 else -> {}
             }
         }

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.psy.dear.domain.model.Journal
+import com.psy.dear.core.asString
 import com.psy.dear.presentation.components.FullScreenLoading
 import com.psy.dear.presentation.components.InfoMessage
 import com.psy.dear.presentation.navigation.Screen
@@ -46,7 +47,7 @@ fun HomeScreen(
                 FullScreenLoading()
             } else if (state.error != null) {
                 InfoMessage(
-                    message = "Gagal memuat data. ${state.error}",
+                    message = state.error.asString(),
                     icon = Icons.Default.CloudOff
                 )
             } else if (state.journals.isEmpty()) {

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeViewModel.kt
@@ -3,6 +3,8 @@ package com.psy.dear.presentation.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.psy.dear.core.Result
+import com.psy.dear.core.ErrorMapper
+import com.psy.dear.core.UiText
 import com.psy.dear.domain.model.Journal
 import com.psy.dear.domain.use_case.journal.GetJournalsUseCase
 import com.psy.dear.domain.use_case.journal.SyncJournalsUseCase
@@ -14,7 +16,7 @@ import javax.inject.Inject
 data class HomeState(
     val journals: List<Journal> = emptyList(),
     val isLoading: Boolean = false,
-    val error: String? = null
+    val error: UiText? = null
 )
 
 @HiltViewModel
@@ -43,7 +45,7 @@ class HomeViewModel @Inject constructor(
             _state.update {
                 it.copy(
                     isLoading = false,
-                    error = if (result is Result.Error) result.exception?.message else null
+                    error = if (result is Result.Error) UiText.StringResource(ErrorMapper.map(result.exception)) else null
                 )
             }
         }

--- a/app/src/main/java/com/psy/dear/presentation/journal_detail/JournalDetailScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/journal_detail/JournalDetailScreen.kt
@@ -15,6 +15,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.psy.dear.presentation.navigation.Screen
 import kotlinx.coroutines.flow.collectLatest
+import com.psy.dear.core.asString
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -30,7 +31,7 @@ fun JournalDetailScreen(
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 DetailEvent.DeleteSuccess -> navController.navigateUp()
-                is DetailEvent.ShowError -> snackbarHostState.showSnackbar(event.message)
+                is DetailEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString())
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/presentation/journal_detail/JournalDetailViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/journal_detail/JournalDetailViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.psy.dear.core.Result
+import com.psy.dear.core.ErrorMapper
+import com.psy.dear.core.UiText
 import com.psy.dear.domain.model.Journal
 import com.psy.dear.domain.use_case.journal.DeleteJournalUseCase
 import com.psy.dear.domain.use_case.journal.GetJournalByIdUseCase
@@ -14,7 +16,7 @@ import javax.inject.Inject
 
 sealed class DetailEvent {
     object DeleteSuccess : DetailEvent()
-    data class ShowError(val message: String) : DetailEvent()
+    data class ShowError(val message: UiText) : DetailEvent()
 }
 
 @HiltViewModel
@@ -40,7 +42,7 @@ class JournalDetailViewModel @Inject constructor(
         viewModelScope.launch {
             when (val result = deleteJournalUseCase(journalId)) {
                 is Result.Success -> _eventFlow.emit(DetailEvent.DeleteSuccess)
-                is Result.Error -> _eventFlow.emit(DetailEvent.ShowError(result.exception?.message ?: "Gagal menghapus"))
+                is Result.Error -> _eventFlow.emit(DetailEvent.ShowError(UiText.StringResource(ErrorMapper.map(result.exception))))
                 else -> {}
             }
         }

--- a/app/src/main/java/com/psy/dear/presentation/journal_editor/JournalEditorScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/journal_editor/JournalEditorScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import kotlinx.coroutines.flow.collectLatest
+import com.psy.dear.core.asString
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -23,7 +24,7 @@ fun JournalEditorScreen(
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 is EditorEvent.SaveSuccess -> navController.navigateUp()
-                is EditorEvent.ShowError -> snackbarHostState.showSnackbar(event.message)
+                is EditorEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString())
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/presentation/journal_editor/JournalEditorViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/journal_editor/JournalEditorViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.psy.dear.core.Result
+import com.psy.dear.core.ErrorMapper
+import com.psy.dear.core.UiText
 import com.psy.dear.domain.use_case.journal.GetJournalByIdUseCase
 import com.psy.dear.domain.use_case.journal.SaveJournalUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,7 +20,7 @@ import javax.inject.Inject
 
 sealed class EditorEvent {
     object SaveSuccess : EditorEvent()
-    data class ShowError(val message: String) : EditorEvent()
+    data class ShowError(val message: UiText) : EditorEvent()
 }
 
 @HiltViewModel
@@ -77,7 +79,7 @@ class JournalEditorViewModel @Inject constructor(
             )
             when (result) {
                 is Result.Success -> _eventFlow.emit(EditorEvent.SaveSuccess)
-                is Result.Error -> _eventFlow.emit(EditorEvent.ShowError(result.exception?.message ?: "Gagal menyimpan"))
+                is Result.Error -> _eventFlow.emit(EditorEvent.ShowError(UiText.StringResource(ErrorMapper.map(result.exception))))
                 else -> {}
             }
         }

--- a/app/src/main/java/com/psy/dear/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/profile/ProfileScreen.kt
@@ -10,6 +10,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.psy.dear.domain.model.User
 import com.psy.dear.presentation.navigation.Screen
+import com.psy.dear.core.asString
 import kotlinx.coroutines.flow.collectLatest
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -38,7 +39,7 @@ fun ProfileScreen(
         Box(modifier = Modifier.fillMaxSize().padding(padding)) {
             when {
                 state.isLoading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                state.error != null -> Text(state.error!!, modifier = Modifier.align(Alignment.Center))
+                state.error != null -> Text(state.error.asString(), modifier = Modifier.align(Alignment.Center))
                 state.user != null -> ProfileContent(user = state.user!!, onLogout = viewModel::logout)
             }
         }

--- a/app/src/main/java/com/psy/dear/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/profile/ProfileViewModel.kt
@@ -3,6 +3,8 @@ package com.psy.dear.presentation.profile
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.psy.dear.core.Result
+import com.psy.dear.core.ErrorMapper
+import com.psy.dear.core.UiText
 import com.psy.dear.domain.model.User
 import com.psy.dear.domain.use_case.auth.LogoutUseCase
 import com.psy.dear.domain.use_case.user.GetUserProfileUseCase
@@ -17,7 +19,7 @@ import javax.inject.Inject
 data class ProfileState(
     val user: User? = null,
     val isLoading: Boolean = false,
-    val error: String? = null
+    val error: UiText? = null
 )
 
 sealed class ProfileEvent {
@@ -45,7 +47,7 @@ class ProfileViewModel @Inject constructor(
             _state.value = _state.value.copy(isLoading = true)
             when (val result = getUserProfileUseCase()) {
                 is Result.Success -> _state.value = ProfileState(user = result.data)
-                is Result.Error -> _state.value = ProfileState(error = result.exception?.message)
+                is Result.Error -> _state.value = ProfileState(error = UiText.StringResource(ErrorMapper.map(result.exception)))
                 is Result.Loading -> {}
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,4 +35,9 @@
     <string name="profile_title">Profil</string>
     <string name="profile_logout_button">Logout</string>
 
+    <!-- Generic Errors -->
+    <string name="error_network">Network error. Please check your connection.</string>
+    <string name="error_unauthorized">Unauthorized. Please log in again.</string>
+    <string name="error_unknown">An unexpected error occurred.</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- map Throwables to string resources via `ErrorMapper`
- represent messages as `UiText` for resource or dynamic text
- include generic error strings
- update view models to emit `UiText`
- display errors using `stringResource`

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `./gradlew assembleDebug` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6859f42684ec832482092d6c8f6bcf5b