### PR TITLE
Switch network base URL to BuildConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ APP_NAME=Dear Diary
 ## Usage
 
 
-Run the backend and then launch the Android app. The app communicates with the API under `http://localhost:8000/api/v1`.
+Run the backend and then launch the Android app. The base URL used by the Android app is provided via `BuildConfig`. Debug builds point to `http://10.0.2.2:8000/api/v1/` so the emulator can reach your machine, while release builds default to `https://yourdomain.com/api/v1/`.
 
 ### Android Usage
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,12 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8000/api/v1/\"")
+        }
         release {
             isMinifyEnabled = false
+            buildConfigField("String", "BASE_URL", "\"https://yourdomain.com/api/v1/\"")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/src/main/java/com/psy/dear/di/NetworkModule.kt
+++ b/app/src/main/java/com/psy/dear/di/NetworkModule.kt
@@ -3,6 +3,7 @@ package com.psy.dear.di
 import com.psy.dear.data.datastore.UserPreferencesRepository
 import com.psy.dear.data.network.AuthInterceptor
 import com.psy.dear.data.network.api.*
+import com.psy.dear.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,9 +18,8 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
-    // Base URL for the FastAPI backend. Adjust as needed for your environment.
-    // Use 10.0.2.2 when running on an Android emulator to reach localhost.
-    private const val BASE_URL = "http://10.0.2.2:8000/api/v1/"
+    // Base URL for the FastAPI backend is provided via BuildConfig.
+
 
     @Provides
     @Singleton
@@ -46,7 +46,7 @@ object NetworkModule {
     @Singleton
     fun provideRetrofit(client: OkHttpClient): Retrofit {
         return Retrofit.Builder()
-            .baseUrl(BASE_URL)
+            .baseUrl(BuildConfig.BASE_URL)
             .client(client)
             .addConverterFactory(GsonConverterFactory.create())
             .build()


### PR DESCRIPTION
## Summary
- configure debug and release build types with BASE_URL
- use `BuildConfig.BASE_URL` in `NetworkModule`
- document the new configuration in the README

## Testing
- `pytest -q` *(fails: test_services_handle_invalid_credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6859f5c356f483249eaa467d3ce3316e