### PR TITLE
Add content resources to home feed

### DIFF
--- a/app/src/main/java/com/psy/dear/data/mappers/Mappers.kt
+++ b/app/src/main/java/com/psy/dear/data/mappers/Mappers.kt
@@ -4,7 +4,10 @@ import com.psy.dear.data.local.entity.ChatMessageEntity
 import com.psy.dear.data.local.entity.JournalEntity
 import com.psy.dear.domain.model.ChatMessage
 import com.psy.dear.domain.model.Journal
-import com.psy.dear.data.network.dto.JournalResponse
+import com.psy.dear.data.network.dto.*
+import com.psy.dear.domain.model.Article
+import com.psy.dear.domain.model.AudioTrack
+import com.psy.dear.domain.model.MotivationalQuote
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -51,3 +54,7 @@ fun ChatMessage.toEntity(): ChatMessageEntity {
         isFlagged = false
     )
 }
+
+fun ArticleResponse.toDomain() = Article(id, title, url)
+fun AudioTrackResponse.toDomain() = AudioTrack(id, title, url)
+fun MotivationalQuoteResponse.toDomain() = MotivationalQuote(id, text, author)

--- a/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
+++ b/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
@@ -35,3 +35,14 @@ interface UserApiService {
     @GET("users/me")
     suspend fun getProfile(): UserProfileResponse
 }
+
+interface ContentApiService {
+    @GET("articles")
+    suspend fun getArticles(): List<ArticleResponse>
+
+    @GET("audio")
+    suspend fun getAudio(): List<AudioTrackResponse>
+
+    @GET("quotes")
+    suspend fun getQuotes(): List<MotivationalQuoteResponse>
+}

--- a/app/src/main/java/com/psy/dear/data/network/dto/Dtos.kt
+++ b/app/src/main/java/com/psy/dear/data/network/dto/Dtos.kt
@@ -36,3 +36,8 @@ data class UserProfileResponse(
     val username: String,
     val email: String
 )
+
+// ContentDtos
+data class ArticleResponse(val id: String, val title: String, val url: String)
+data class AudioTrackResponse(val id: String, val title: String, val url: String)
+data class MotivationalQuoteResponse(val id: String, val text: String, val author: String)

--- a/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
@@ -10,6 +10,7 @@ import com.psy.dear.data.network.api.AuthApiService
 import com.psy.dear.data.network.api.ChatApiService
 import com.psy.dear.data.network.api.JournalApiService
 import com.psy.dear.data.network.api.UserApiService
+import com.psy.dear.data.network.api.ContentApiService
 import com.psy.dear.core.UnauthorizedException
 import com.psy.dear.data.network.dto.ChatRequest
 import com.psy.dear.data.network.dto.CreateJournalRequest
@@ -21,9 +22,11 @@ import com.psy.dear.domain.repository.AuthRepository
 import com.psy.dear.domain.repository.ChatRepository
 import com.psy.dear.domain.repository.JournalRepository
 import com.psy.dear.domain.repository.UserRepository
+import com.psy.dear.domain.repository.ContentRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.flow
 import java.time.OffsetDateTime
 import java.util.*
 import javax.inject.Inject
@@ -153,5 +156,22 @@ class ChatRepositoryImpl @Inject constructor(
         Result.Success(Unit)
     } catch (e: Exception) {
         Result.Error(e)
+    }
+}
+
+@Singleton
+class ContentRepositoryImpl @Inject constructor(
+    private val api: ContentApiService
+) : ContentRepository {
+    override fun getArticles(): Flow<List<Article>> = flow {
+        emit(api.getArticles().map { it.toDomain() })
+    }
+
+    override fun getAudioTracks(): Flow<List<AudioTrack>> = flow {
+        emit(api.getAudio().map { it.toDomain() })
+    }
+
+    override fun getQuotes(): Flow<List<MotivationalQuote>> = flow {
+        emit(api.getQuotes().map { it.toDomain() })
     }
 }

--- a/app/src/main/java/com/psy/dear/di/NetworkModule.kt
+++ b/app/src/main/java/com/psy/dear/di/NetworkModule.kt
@@ -67,4 +67,8 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideUserApiService(retrofit: Retrofit): UserApiService = retrofit.create(UserApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideContentApiService(retrofit: Retrofit): ContentApiService = retrofit.create(ContentApiService::class.java)
 }

--- a/app/src/main/java/com/psy/dear/di/RepositoryModule.kt
+++ b/app/src/main/java/com/psy/dear/di/RepositoryModule.kt
@@ -27,4 +27,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindChatRepository(impl: ChatRepositoryImpl): ChatRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindContentRepository(impl: ContentRepositoryImpl): ContentRepository
 }

--- a/app/src/main/java/com/psy/dear/domain/model/Models.kt
+++ b/app/src/main/java/com/psy/dear/domain/model/Models.kt
@@ -35,3 +35,21 @@ data class TestOption(val text: String, val value: Int)
 data class DassQuestion(val text: String, val scale: String)
 
 data class MbtiQuestion(val text: String, val positivePole: String, val negativePole: String)
+
+data class Article(
+    val id: String,
+    val title: String,
+    val url: String
+)
+
+data class AudioTrack(
+    val id: String,
+    val title: String,
+    val url: String
+)
+
+data class MotivationalQuote(
+    val id: String,
+    val text: String,
+    val author: String
+)

--- a/app/src/main/java/com/psy/dear/domain/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/domain/repository/Repositories.kt
@@ -31,3 +31,9 @@ interface ChatRepository {
     suspend fun deleteMessage(id: String): Result<Unit>
     suspend fun flagMessage(id: String, flagged: Boolean): Result<Unit>
 }
+
+interface ContentRepository {
+    fun getArticles(): Flow<List<Article>>
+    fun getAudioTracks(): Flow<List<AudioTrack>>
+    fun getQuotes(): Flow<List<MotivationalQuote>>
+}

--- a/app/src/main/java/com/psy/dear/domain/use_case/content/UseCases.kt
+++ b/app/src/main/java/com/psy/dear/domain/use_case/content/UseCases.kt
@@ -1,0 +1,20 @@
+package com.psy.dear.domain.use_case.content
+
+import com.psy.dear.domain.model.Article
+import com.psy.dear.domain.model.AudioTrack
+import com.psy.dear.domain.model.MotivationalQuote
+import com.psy.dear.domain.repository.ContentRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetArticlesUseCase @Inject constructor(private val repo: ContentRepository) {
+    operator fun invoke(): Flow<List<Article>> = repo.getArticles()
+}
+
+class GetAudioTracksUseCase @Inject constructor(private val repo: ContentRepository) {
+    operator fun invoke(): Flow<List<AudioTrack>> = repo.getAudioTracks()
+}
+
+class GetQuotesUseCase @Inject constructor(private val repo: ContentRepository) {
+    operator fun invoke(): Flow<List<MotivationalQuote>> = repo.getQuotes()
+}

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeCards.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeCards.kt
@@ -1,0 +1,69 @@
+package com.psy.dear.presentation.home
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.psy.dear.domain.model.*
+
+@Composable
+fun GreetingCard(userName: String) {
+    Card(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+        Text(
+            text = "Hello, $userName",
+            modifier = Modifier.padding(16.dp),
+            style = MaterialTheme.typography.titleMedium
+        )
+    }
+}
+
+@Composable
+fun JournalPromptCard(onClick: () -> Unit) {
+    Card(modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text("Tulis jurnal harianmu", style = MaterialTheme.typography.titleMedium)
+        }
+    }
+}
+
+@Composable
+fun ArticleCard(article: Article) {
+    Card(modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Column(Modifier.padding(16.dp)) {
+            Text(article.title, style = MaterialTheme.typography.titleMedium)
+            Text(article.url, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+fun AudioCard(track: AudioTrack) {
+    Card(modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Column(Modifier.padding(16.dp)) {
+            Text(track.title, style = MaterialTheme.typography.titleMedium)
+            Text(track.url, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+fun MotivationCard(quote: MotivationalQuote) {
+    Card(modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 16.dp, vertical = 8.dp)) {
+        Column(Modifier.padding(16.dp)) {
+            Text("\"${quote.text}\"", style = MaterialTheme.typography.bodyMedium)
+            Text("- ${quote.author}", style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
@@ -20,6 +20,11 @@ import com.psy.dear.domain.model.Journal
 import com.psy.dear.core.asString
 import com.psy.dear.presentation.components.FullScreenLoading
 import com.psy.dear.presentation.components.InfoMessage
+import com.psy.dear.presentation.home.ArticleCard
+import com.psy.dear.presentation.home.AudioCard
+import com.psy.dear.presentation.home.GreetingCard
+import com.psy.dear.presentation.home.JournalPromptCard
+import com.psy.dear.presentation.home.MotivationCard
 import com.psy.dear.presentation.navigation.Screen
 import java.time.format.DateTimeFormatter
 
@@ -50,10 +55,13 @@ fun HomeScreen(
                     message = state.error.asString(),
                     icon = Icons.Default.CloudOff
                 )
-            } else if (state.journals.isEmpty()) {
-                InfoMessage(message = "Belum ada entri jurnal.\nTekan '+' untuk memulai.")
             } else {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    item { GreetingCard("User") }
+                    item { JournalPromptCard { navController.navigate(Screen.JournalEditor.createRoute(null)) } }
+                    items(state.articles) { ArticleCard(it) }
+                    items(state.audio) { AudioCard(it) }
+                    items(state.quotes) { MotivationCard(it) }
                     items(state.journals, key = { it.id }) { journal ->
                         JournalItem(
                             journal = journal,

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeViewModel.kt
@@ -5,9 +5,12 @@ import androidx.lifecycle.viewModelScope
 import com.psy.dear.core.Result
 import com.psy.dear.core.ErrorMapper
 import com.psy.dear.core.UiText
-import com.psy.dear.domain.model.Journal
+import com.psy.dear.domain.model.*
 import com.psy.dear.domain.use_case.journal.GetJournalsUseCase
 import com.psy.dear.domain.use_case.journal.SyncJournalsUseCase
+import com.psy.dear.domain.use_case.content.GetArticlesUseCase
+import com.psy.dear.domain.use_case.content.GetAudioTracksUseCase
+import com.psy.dear.domain.use_case.content.GetQuotesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -15,6 +18,9 @@ import javax.inject.Inject
 
 data class HomeState(
     val journals: List<Journal> = emptyList(),
+    val articles: List<Article> = emptyList(),
+    val audio: List<AudioTrack> = emptyList(),
+    val quotes: List<MotivationalQuote> = emptyList(),
     val isLoading: Boolean = false,
     val error: UiText? = null
 )
@@ -22,7 +28,10 @@ data class HomeState(
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     getJournalsUseCase: GetJournalsUseCase,
-    private val syncJournalsUseCase: SyncJournalsUseCase
+    private val syncJournalsUseCase: SyncJournalsUseCase,
+    getArticlesUseCase: GetArticlesUseCase,
+    getAudioTracksUseCase: GetAudioTracksUseCase,
+    getQuotesUseCase: GetQuotesUseCase
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(HomeState())
@@ -32,6 +41,24 @@ class HomeViewModel @Inject constructor(
         getJournalsUseCase()
             .onEach { journals ->
                 _state.update { it.copy(journals = journals, error = null) }
+            }
+            .launchIn(viewModelScope)
+
+        getArticlesUseCase()
+            .onEach { articles ->
+                _state.update { it.copy(articles = articles) }
+            }
+            .launchIn(viewModelScope)
+
+        getAudioTracksUseCase()
+            .onEach { tracks ->
+                _state.update { it.copy(audio = tracks) }
+            }
+            .launchIn(viewModelScope)
+
+        getQuotesUseCase()
+            .onEach { quotes ->
+                _state.update { it.copy(quotes = quotes) }
             }
             .launchIn(viewModelScope)
 

--- a/app/src/test/java/com/psy/dear/data/repository/FakeContentRepository.kt
+++ b/app/src/test/java/com/psy/dear/data/repository/FakeContentRepository.kt
@@ -1,0 +1,23 @@
+package com.psy.dear.data.repository
+
+import com.psy.dear.domain.model.Article
+import com.psy.dear.domain.model.AudioTrack
+import com.psy.dear.domain.model.MotivationalQuote
+import com.psy.dear.domain.repository.ContentRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeContentRepository : ContentRepository {
+    private val articlesFlow = MutableStateFlow<List<Article>>(emptyList())
+    private val audioFlow = MutableStateFlow<List<AudioTrack>>(emptyList())
+    private val quotesFlow = MutableStateFlow<List<MotivationalQuote>>(emptyList())
+
+    fun setArticles(list: List<Article>) { articlesFlow.value = list }
+    fun setAudio(list: List<AudioTrack>) { audioFlow.value = list }
+    fun setQuotes(list: List<MotivationalQuote>) { quotesFlow.value = list }
+
+    override fun getArticles(): Flow<List<Article>> = articlesFlow.asStateFlow()
+    override fun getAudioTracks(): Flow<List<AudioTrack>> = audioFlow.asStateFlow()
+    override fun getQuotes(): Flow<List<MotivationalQuote>> = quotesFlow.asStateFlow()
+}

--- a/app/src/test/java/com/psy/dear/presentation/home/ArticleCardTest.kt
+++ b/app/src/test/java/com/psy/dear/presentation/home/ArticleCardTest.kt
@@ -1,0 +1,19 @@
+package com.psy.dear.presentation.home
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.assertIsDisplayed
+import org.junit.Rule
+import org.junit.Test
+import com.psy.dear.domain.model.Article
+
+class ArticleCardTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun articleCardDisplaysTitle() {
+        composeRule.setContent { ArticleCard(Article("1","Title","url")) }
+        composeRule.onNodeWithText("Title").assertIsDisplayed()
+    }
+}

--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -1,9 +1,12 @@
 from fastapi import APIRouter
-from app.api.v1 import auth, journal, chat, user
+from app.api.v1 import auth, journal, chat, user, article, audio, quote
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(journal.router, prefix="/journals", tags=["journals"])
 api_router.include_router(chat.router, prefix="/chat", tags=["chat"])
 api_router.include_router(user.router, tags=["users"])
+api_router.include_router(article.router, prefix="/articles", tags=["articles"])
+api_router.include_router(audio.router, prefix="/audio", tags=["audio"])
+api_router.include_router(quote.router, prefix="/quotes", tags=["quotes"])
 

--- a/backend/app/api/v1/article.py
+++ b/backend/app/api/v1/article.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from app import crud, models, schemas
+from app.dependencies import get_db
+
+router = APIRouter()
+
+@router.get("/", response_model=list[schemas.Article])
+def get_articles(db: Session = Depends(get_db)):
+    return crud.article.get_multi(db)

--- a/backend/app/api/v1/audio.py
+++ b/backend/app/api/v1/audio.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from app import crud, schemas
+from app.dependencies import get_db
+
+router = APIRouter()
+
+@router.get("/", response_model=list[schemas.AudioTrack])
+def get_audio(db: Session = Depends(get_db)):
+    return crud.audio_track.get_multi(db)

--- a/backend/app/api/v1/quote.py
+++ b/backend/app/api/v1/quote.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from app import crud, schemas
+from app.dependencies import get_db
+
+router = APIRouter()
+
+@router.get("/", response_model=list[schemas.MotivationalQuote])
+def get_quotes(db: Session = Depends(get_db)):
+    return crud.motivational_quote.get_multi(db)

--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -2,6 +2,9 @@ from .crud_user import CRUDUser, user
 from .crud_journal import CRUDJournal, journal
 from .base import CRUDBase
 from .crud_chat import chat_message
+from .crud_article import article
+from .crud_audio import audio_track
+from .crud_motivational_quote import motivational_quote
 
 
 __all__ = [
@@ -11,5 +14,8 @@ __all__ = [
     "user",
     "journal",
     "chat_message",
+    "article",
+    "audio_track",
+    "motivational_quote",
 ]
 

--- a/backend/app/crud/crud_article.py
+++ b/backend/app/crud/crud_article.py
@@ -1,0 +1,9 @@
+from sqlalchemy.orm import Session
+from .base import CRUDBase
+from app.models.article import Article
+from app.schemas.article import ArticleCreate, ArticleUpdate
+
+class CRUDArticle(CRUDBase[Article, ArticleCreate, ArticleUpdate]):
+    pass
+
+article = CRUDArticle(Article)

--- a/backend/app/crud/crud_audio.py
+++ b/backend/app/crud/crud_audio.py
@@ -1,0 +1,9 @@
+from sqlalchemy.orm import Session
+from .base import CRUDBase
+from app.models.audio import AudioTrack
+from app.schemas.audio import AudioTrackCreate, AudioTrackUpdate
+
+class CRUDAudioTrack(CRUDBase[AudioTrack, AudioTrackCreate, AudioTrackUpdate]):
+    pass
+
+audio_track = CRUDAudioTrack(AudioTrack)

--- a/backend/app/crud/crud_motivational_quote.py
+++ b/backend/app/crud/crud_motivational_quote.py
@@ -1,0 +1,9 @@
+from sqlalchemy.orm import Session
+from .base import CRUDBase
+from app.models.motivational_quote import MotivationalQuote
+from app.schemas.motivational_quote import MotivationalQuoteCreate, MotivationalQuoteUpdate
+
+class CRUDMotivationalQuote(CRUDBase[MotivationalQuote, MotivationalQuoteCreate, MotivationalQuoteUpdate]):
+    pass
+
+motivational_quote = CRUDMotivationalQuote(MotivationalQuote)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,16 @@
 from .user import User
 from .journal import Journal
 from .chat import ChatMessage
+from .article import Article
+from .audio import AudioTrack
+from .motivational_quote import MotivationalQuote
 
-__all__ = ["User", "Journal", "ChatMessage"]
+__all__ = [
+    "User",
+    "Journal",
+    "ChatMessage",
+    "Article",
+    "AudioTrack",
+    "MotivationalQuote",
+]
 

--- a/backend/app/models/article.py
+++ b/backend/app/models/article.py
@@ -1,0 +1,7 @@
+from sqlalchemy import Column, Integer, String
+from app.db.base_class import Base
+
+class Article(Base):
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String)
+    url = Column(String)

--- a/backend/app/models/audio.py
+++ b/backend/app/models/audio.py
@@ -1,0 +1,7 @@
+from sqlalchemy import Column, Integer, String
+from app.db.base_class import Base
+
+class AudioTrack(Base):
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String)
+    url = Column(String)

--- a/backend/app/models/motivational_quote.py
+++ b/backend/app/models/motivational_quote.py
@@ -1,0 +1,7 @@
+from sqlalchemy import Column, Integer, String
+from app.db.base_class import Base
+
+class MotivationalQuote(Base):
+    id = Column(Integer, primary_key=True, index=True)
+    text = Column(String)
+    author = Column(String)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -2,6 +2,9 @@ from .user import UserBase, UserCreate, UserUpdate, UserInDB, UserPublic, UserLo
 from .journal import JournalBase, JournalCreate, JournalUpdate, JournalInDB
 from .token import Token, TokenPayload
 from .chat import ChatMessage
+from .article import Article, ArticleCreate, ArticleUpdate
+from .audio import AudioTrack, AudioTrackCreate, AudioTrackUpdate
+from .motivational_quote import MotivationalQuote, MotivationalQuoteCreate, MotivationalQuoteUpdate
 
 __all__ = [
     "UserBase",
@@ -17,5 +20,14 @@ __all__ = [
     "Token",
     "TokenPayload",
     "ChatMessage",
+    "Article",
+    "ArticleCreate",
+    "ArticleUpdate",
+    "AudioTrack",
+    "AudioTrackCreate",
+    "AudioTrackUpdate",
+    "MotivationalQuote",
+    "MotivationalQuoteCreate",
+    "MotivationalQuoteUpdate",
 ]
 

--- a/backend/app/schemas/article.py
+++ b/backend/app/schemas/article.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, ConfigDict
+
+class ArticleBase(BaseModel):
+    title: str
+    url: str
+
+class ArticleCreate(ArticleBase):
+    pass
+
+class ArticleUpdate(ArticleBase):
+    pass
+
+class Article(ArticleBase):
+    id: int
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/audio.py
+++ b/backend/app/schemas/audio.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, ConfigDict
+
+class AudioTrackBase(BaseModel):
+    title: str
+    url: str
+
+class AudioTrackCreate(AudioTrackBase):
+    pass
+
+class AudioTrackUpdate(AudioTrackBase):
+    pass
+
+class AudioTrack(AudioTrackBase):
+    id: int
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/motivational_quote.py
+++ b/backend/app/schemas/motivational_quote.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, ConfigDict
+
+class MotivationalQuoteBase(BaseModel):
+    text: str
+    author: str
+
+class MotivationalQuoteCreate(MotivationalQuoteBase):
+    pass
+
+class MotivationalQuoteUpdate(MotivationalQuoteBase):
+    pass
+
+class MotivationalQuote(MotivationalQuoteBase):
+    id: int
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- define new models Article, AudioTrack and MotivationalQuote
- add content API service and repository implementation
- expose new content use-cases
- load articles, audio tracks and quotes in HomeViewModel
- display GreetingCard, JournalPromptCard, ArticleCard, AudioCard and MotivationCard in HomeScreen
- expand unit tests
- add backend models, CRUD and API routes for new resources

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6859f7f57eac832481013b739e998188