### PR TITLE
Add context-based UiText resolver

### DIFF
--- a/app/src/main/java/com/psy/dear/core/UiText.kt
+++ b/app/src/main/java/com/psy/dear/core/UiText.kt
@@ -1,5 +1,6 @@
 package com.psy.dear.core
 
+import android.content.Context
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
@@ -7,6 +8,11 @@ import androidx.compose.ui.res.stringResource
 sealed class UiText {
     data class DynamicString(val value: String) : UiText()
     data class StringResource(@StringRes val resId: Int) : UiText()
+}
+
+fun UiText.asString(context: Context): String = when (this) {
+    is UiText.DynamicString -> value
+    is UiText.StringResource -> context.getString(resId)
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- add an Android `Context` based overload for `UiText.asString`
- keep the existing `@Composable` version untouched

## Testing
- `pytest -q backend/tests` *(fails: test_services_handle_invalid_credentials)*
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685a010457c88324b7a6bfb11ad1e461