### PR TITLE
Use context when handling login error

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/auth/login/LoginScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/auth/login/LoginScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.psy.dear.R
@@ -22,12 +23,13 @@ fun LoginScreen(
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 is LoginEvent.LoginSuccess -> onLoginSuccess()
-                is LoginEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString())
+                is LoginEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString(context))
             }
         }
     }


### PR DESCRIPTION
## Summary
- read `LocalContext.current` inside `LoginScreen`
- forward the context to `asString` when showing login errors

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685a011c6a70832494661947a60a4196