### PR TITLE
Update RegisterScreen snackbar context

### DIFF
--- a/app/src/main/java/com/psy/dear/core/UiText.kt
+++ b/app/src/main/java/com/psy/dear/core/UiText.kt
@@ -1,5 +1,6 @@
 package com.psy.dear.core
 
+import android.content.Context
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
@@ -13,4 +14,9 @@ sealed class UiText {
 fun UiText.asString(): String = when (this) {
     is UiText.DynamicString -> value
     is UiText.StringResource -> stringResource(id = resId)
+}
+
+fun UiText.asString(context: Context): String = when (this) {
+    is UiText.DynamicString -> value
+    is UiText.StringResource -> context.getString(resId)
 }

--- a/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import android.util.Patterns
@@ -23,12 +24,13 @@ fun RegisterScreen(
     var password by remember { mutableStateOf("") }
     val isEmailValid by derivedStateOf { Patterns.EMAIL_ADDRESS.matcher(email).matches() }
     val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 is RegisterEvent.RegisterSuccess -> onRegisterSuccess()
-                is RegisterEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString())
+                is RegisterEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString(context))
             }
         }
     }


### PR DESCRIPTION
## Summary
- extend `UiText.asString` to accept a `Context`
- show RegisterScreen errors using `asString(context)`

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685a011d3e4c8324b7a1e20a22ee3220