### PR TITLE
Fix snackbar message context

### DIFF
--- a/app/src/main/java/com/psy/dear/core/UiText.kt
+++ b/app/src/main/java/com/psy/dear/core/UiText.kt
@@ -1,6 +1,7 @@
 package com.psy.dear.core
 
 import androidx.annotation.StringRes
+import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 
@@ -13,4 +14,9 @@ sealed class UiText {
 fun UiText.asString(): String = when (this) {
     is UiText.DynamicString -> value
     is UiText.StringResource -> stringResource(id = resId)
+}
+
+fun UiText.asString(context: Context): String = when (this) {
+    is UiText.DynamicString -> value
+    is UiText.StringResource -> context.getString(resId)
 }

--- a/app/src/main/java/com/psy/dear/presentation/auth/login/LoginScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/auth/login/LoginScreen.kt
@@ -3,6 +3,7 @@ package com.psy.dear.presentation.auth.login
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -21,13 +22,14 @@ fun LoginScreen(
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 is LoginEvent.LoginSuccess -> onLoginSuccess()
-                is LoginEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString())
+                is LoginEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString(context))
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/auth/register/RegisterScreen.kt
@@ -3,6 +3,7 @@ package com.psy.dear.presentation.auth.register
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -22,13 +23,14 @@ fun RegisterScreen(
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     val isEmailValid by derivedStateOf { Patterns.EMAIL_ADDRESS.matcher(email).matches() }
+    val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 is RegisterEvent.RegisterSuccess -> onRegisterSuccess()
-                is RegisterEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString())
+                is RegisterEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString(context))
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/presentation/journal_detail/JournalDetailScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/journal_detail/JournalDetailScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -24,6 +25,7 @@ fun JournalDetailScreen(
     viewModel: JournalDetailViewModel = hiltViewModel()
 ) {
     val journal by viewModel.journal.collectAsState()
+    val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
     var showDeleteDialog by remember { mutableStateOf(false) }
 
@@ -31,7 +33,7 @@ fun JournalDetailScreen(
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 DetailEvent.DeleteSuccess -> navController.navigateUp()
-                is DetailEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString())
+                is DetailEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString(context))
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/presentation/journal_editor/JournalEditorScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/journal_editor/JournalEditorScreen.kt
@@ -3,6 +3,7 @@ package com.psy.dear.presentation.journal_editor
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -18,13 +19,14 @@ fun JournalEditorScreen(
 ) {
     var title by remember { mutableStateOf("") }
     var content by remember { mutableStateOf("") }
+    val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 is EditorEvent.SaveSuccess -> navController.navigateUp()
-                is EditorEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString())
+                is EditorEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString(context))
             }
         }
     }


### PR DESCRIPTION
## Summary
- overload `UiText.asString` with a Context parameter
- capture `LocalContext.current` in screens
- pass the context when showing snackbars

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685a011ed2a48324adc776070b10d2f9