### PR TITLE
Handle EditorEvent.ShowError with context

### DIFF
--- a/app/src/main/java/com/psy/dear/core/UiText.kt
+++ b/app/src/main/java/com/psy/dear/core/UiText.kt
@@ -3,6 +3,7 @@ package com.psy.dear.core
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
+import android.content.Context
 
 sealed class UiText {
     data class DynamicString(val value: String) : UiText()
@@ -13,4 +14,9 @@ sealed class UiText {
 fun UiText.asString(): String = when (this) {
     is UiText.DynamicString -> value
     is UiText.StringResource -> stringResource(id = resId)
+}
+
+fun UiText.asString(context: Context): String = when (this) {
+    is UiText.DynamicString -> value
+    is UiText.StringResource -> context.getString(resId)
 }

--- a/app/src/main/java/com/psy/dear/presentation/journal_editor/JournalEditorScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/journal_editor/JournalEditorScreen.kt
@@ -4,11 +4,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import kotlinx.coroutines.flow.collectLatest
-import com.psy.dear.core.asString
+import com.psy.dear.ui.utils.showSnackbar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -19,12 +20,13 @@ fun JournalEditorScreen(
     var title by remember { mutableStateOf("") }
     var content by remember { mutableStateOf("") }
     val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 is EditorEvent.SaveSuccess -> navController.navigateUp()
-                is EditorEvent.ShowError -> snackbarHostState.showSnackbar(event.message.asString())
+                is EditorEvent.ShowError -> snackbarHostState.showSnackbar(context, event.message)
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/ui/utils/SnackbarUtils.kt
+++ b/app/src/main/java/com/psy/dear/ui/utils/SnackbarUtils.kt
@@ -1,0 +1,10 @@
+package com.psy.dear.ui.utils
+
+import android.content.Context
+import androidx.compose.material3.SnackbarHostState
+import com.psy.dear.core.UiText
+import com.psy.dear.core.asString
+
+suspend fun SnackbarHostState.showSnackbar(context: Context, message: UiText) {
+    showSnackbar(message.asString(context))
+}


### PR DESCRIPTION
## Summary
- add context overload for `UiText.asString`
- add Snackbar utilities for context-aware display
- show error Snackbars using context in `JournalEditorScreen`

## Testing
- `./gradlew testDebugUnitTest` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685a011ee0788324982f825ba5e8edb7