### PR TITLE
Fix null check in Growth/Profile screens

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
@@ -27,8 +27,10 @@ fun GrowthScreen(
         Box(modifier = Modifier.fillMaxSize().padding(padding)) {
             when {
                 state.isLoading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                state.error != null -> Text(text = state.error.asString(), modifier = Modifier.align(Alignment.Center))
                 state.stats != null -> StatisticsContent(stats = state.stats!!)
+                else -> state.error?.let {
+                    Text(text = it.asString(), modifier = Modifier.align(Alignment.Center))
+                }
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/profile/ProfileScreen.kt
@@ -39,8 +39,10 @@ fun ProfileScreen(
         Box(modifier = Modifier.fillMaxSize().padding(padding)) {
             when {
                 state.isLoading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                state.error != null -> Text(state.error.asString(), modifier = Modifier.align(Alignment.Center))
                 state.user != null -> ProfileContent(user = state.user!!, onLogout = viewModel::logout)
+                else -> state.error?.let {
+                    Text(it.asString(), modifier = Modifier.align(Alignment.Center))
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- guard against null errors in GrowthScreen and ProfileScreen using `let`

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests` *(fails: test_openrouter_credentials)*

------
https://chatgpt.com/codex/tasks/task_e_685a012096dc8324ba86c755184042e2