### PR TITLE
Refactor HomeScreen error handling

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
@@ -48,15 +48,11 @@ fun HomeScreen(
         }
     ) { padding ->
         Box(modifier = Modifier.padding(padding).pullRefresh(pullRefreshState)) {
+            val error = state.error
             if (state.isLoading && state.journals.isEmpty()) {
                 FullScreenLoading()
-            } else if (state.error != null) {
-                InfoMessage(
-                    message = state.error.asString(),
-                    icon = Icons.Default.CloudOff
-                )
             } else {
-                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                error?.let { InfoMessage(message = it.asString(), icon = Icons.Default.CloudOff) } ?: LazyColumn(modifier = Modifier.fillMaxSize()) {
                     item { GreetingCard("User") }
                     item { JournalPromptCard { navController.navigate(Screen.JournalEditor.createRoute(null)) } }
                     items(state.articles) { ArticleCard(it) }


### PR DESCRIPTION
## Summary
- simplify error presentation in HomeScreen by extracting `state.error`

## Testing
- `pytest backend/tests` *(fails: test_services_handle_invalid_credentials)*
- `./gradlew test` *(fails to run Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685a0121bf6c832482672613312978f7