### PR TITLE
Fix error display in screens

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
@@ -27,7 +27,9 @@ fun GrowthScreen(
         Box(modifier = Modifier.fillMaxSize().padding(padding)) {
             when {
                 state.isLoading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                state.error != null -> Text(text = state.error.asString(), modifier = Modifier.align(Alignment.Center))
+                state.error != null -> state.error?.let {
+                    Text(it.asString(), modifier = Modifier.align(Alignment.Center))
+                }
                 state.stats != null -> StatisticsContent(stats = state.stats!!)
             }
         }

--- a/app/src/main/java/com/psy/dear/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/profile/ProfileScreen.kt
@@ -39,7 +39,9 @@ fun ProfileScreen(
         Box(modifier = Modifier.fillMaxSize().padding(padding)) {
             when {
                 state.isLoading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                state.error != null -> Text(state.error.asString(), modifier = Modifier.align(Alignment.Center))
+                state.error != null -> state.error?.let {
+                    Text(it.asString(), modifier = Modifier.align(Alignment.Center))
+                }
                 state.user != null -> ProfileContent(user = state.user!!, onLogout = viewModel::logout)
             }
         }


### PR DESCRIPTION
## Summary
- update error handling in `GrowthScreen` with `let` expression
- update error handling in `ProfileScreen` with `let` expression

## Testing
- `pytest backend/tests` *(fails: FAILED backend/tests/test_openrouter_credentials.py::test_services_handle_invalid_credentials[None])*

------
https://chatgpt.com/codex/tasks/task_e_685a01228edc832488aef7a45b9c99b0