### PR TITLE
Refine error display

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
@@ -34,9 +34,9 @@ fun GrowthScreen(
                 state.stats != null -> {
                     StatisticsContent(stats = state.stats!!)
                 }
-                state.error != null -> {
+                state.error != null -> state.error?.let { error ->
                     Text(
-                        text = state.error.asString(),
+                        text = error.asString(),
                         modifier = Modifier.align(Alignment.Center),
                         color = MaterialTheme.colorScheme.error
                     )

--- a/app/src/main/java/com/psy/dear/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/profile/ProfileScreen.kt
@@ -44,9 +44,9 @@ fun ProfileScreen(
                 state.user != null -> {
                     ProfileContent(user = state.user!!, onLogout = viewModel::logout)
                 }
-                state.error != null -> {
+                state.error != null -> state.error?.let { error ->
                     Text(
-                        text = state.error.asString(),
+                        text = error.asString(),
                         modifier = Modifier.align(Alignment.Center),
                         color = MaterialTheme.colorScheme.error
                     )


### PR DESCRIPTION
## Summary
- tweak GrowthScreen and ProfileScreen to use `let` for the error message

## Testing
- `pytest backend/tests` *(fails: test_openrouter_credentials)*

------
https://chatgpt.com/codex/tasks/task_e_685a1810c9408324b5fd68e4e5f9a755