### PR TITLE
Fix error display and enable buildConfig

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.8"

--- a/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
@@ -34,13 +34,13 @@ fun GrowthScreen(
                 state.stats != null -> {
                     StatisticsContent(stats = state.stats!!)
                 }
-                state.error != null -> state.error?.let { error ->
-                    Text(
-                        text = error.asString(),
-                        modifier = Modifier.align(Alignment.Center),
-                        color = MaterialTheme.colorScheme.error
-                    )
-                }
+            }
+            state.error?.let { error ->
+                Text(
+                    text = error.asString(),
+                    modifier = Modifier.align(Alignment.Center),
+                    color = MaterialTheme.colorScheme.error
+                )
             }
         }
     }

--- a/app/src/main/java/com/psy/dear/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/profile/ProfileScreen.kt
@@ -44,13 +44,13 @@ fun ProfileScreen(
                 state.user != null -> {
                     ProfileContent(user = state.user!!, onLogout = viewModel::logout)
                 }
-                state.error != null -> state.error?.let { error ->
-                    Text(
-                        text = error.asString(),
-                        modifier = Modifier.align(Alignment.Center),
-                        color = MaterialTheme.colorScheme.error
-                    )
-                }
+            }
+            state.error?.let { error ->
+                Text(
+                    text = error.asString(),
+                    modifier = Modifier.align(Alignment.Center),
+                    color = MaterialTheme.colorScheme.error
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- show API error text in GrowthScreen and ProfileScreen
- enable generation of BuildConfig so app module compiles

## Testing
- `gradle :app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1d3c43588324a28f8dfe9f16c47d