### PR TITLE
Add digital theme colors and shapes

### DIFF
--- a/app/src/main/java/com/psy/dear/ui/theme/Color.kt
+++ b/app/src/main/java/com/psy/dear/ui/theme/Color.kt
@@ -16,3 +16,9 @@ val UserBubble = Color(0xFFDCF8C6)
 val OtherBubble = Color(0xFFFFFFFF)
 val ChatAppBar = Color(0xFF075E54)
 val IconInactive = Color(0xFFAAB8B8)
+
+// Digital theme colors
+val DigitalBackground = Color(0xFF101010)
+val DigitalSurface = Color(0xFF1E1E1E)
+val DigitalPrimary = Color(0xFF00C853)
+val DigitalSecondary = Color(0xFF64DD17)

--- a/app/src/main/java/com/psy/dear/ui/theme/Shapes.kt
+++ b/app/src/main/java/com/psy/dear/ui/theme/Shapes.kt
@@ -1,0 +1,13 @@
+package com.psy.dear.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+val Shapes = Shapes(
+    extraSmall = RoundedCornerShape(8.dp),
+    small = RoundedCornerShape(12.dp),
+    medium = RoundedCornerShape(16.dp),
+    large = RoundedCornerShape(24.dp),
+    extraLarge = RoundedCornerShape(32.dp)
+)

--- a/app/src/main/java/com/psy/dear/ui/theme/Theme.kt
+++ b/app/src/main/java/com/psy/dear/ui/theme/Theme.kt
@@ -16,15 +16,19 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80
+    primary = DigitalPrimary,
+    secondary = DigitalSecondary,
+    tertiary = Pink80,
+    background = DigitalBackground,
+    surface = DigitalSurface
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40
+    primary = DigitalPrimary,
+    secondary = DigitalSecondary,
+    tertiary = Pink40,
+    background = DigitalBackground,
+    surface = DigitalSurface
 )
 
 @Composable
@@ -53,6 +57,7 @@ fun DearTheme(
     MaterialTheme(
         colorScheme = colorScheme,
         typography = Typography,
+        shapes = Shapes,
         content = content
     )
 }


### PR DESCRIPTION
## Summary
- introduce digital theme color palette
- create shape defaults with large corner radius
- hook Shapes into DearTheme

## Testing
- `pytest backend/tests` *(fails: test_services_handle_invalid_credentials)*

------
https://chatgpt.com/codex/tasks/task_e_685a27f897908324972202bd7b7667ad