### PR TITLE
Add username support on home screen

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
@@ -53,7 +53,7 @@ fun HomeScreen(
                 FullScreenLoading()
             } else {
                 error?.let { InfoMessage(message = it.asString(), icon = Icons.Default.CloudOff) } ?: LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    item { GreetingCard("User") }
+                    item { GreetingCard(state.username) }
                     item { JournalPromptCard { navController.navigate(Screen.JournalEditor.createRoute(null)) } }
                     items(state.articles) { ArticleCard(it) }
                     items(state.audio) { AudioCard(it) }

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeViewModel.kt
@@ -11,6 +11,7 @@ import com.psy.dear.domain.use_case.journal.SyncJournalsUseCase
 import com.psy.dear.domain.use_case.content.GetArticlesUseCase
 import com.psy.dear.domain.use_case.content.GetAudioTracksUseCase
 import com.psy.dear.domain.use_case.content.GetQuotesUseCase
+import com.psy.dear.domain.use_case.user.GetUserProfileUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -22,7 +23,8 @@ data class HomeState(
     val audio: List<AudioTrack> = emptyList(),
     val quotes: List<MotivationalQuote> = emptyList(),
     val isLoading: Boolean = false,
-    val error: UiText? = null
+    val error: UiText? = null,
+    val username: String = "User"
 )
 
 @HiltViewModel
@@ -31,7 +33,8 @@ class HomeViewModel @Inject constructor(
     private val syncJournalsUseCase: SyncJournalsUseCase,
     getArticlesUseCase: GetArticlesUseCase,
     getAudioTracksUseCase: GetAudioTracksUseCase,
-    getQuotesUseCase: GetQuotesUseCase
+    getQuotesUseCase: GetQuotesUseCase,
+    private val getUserProfileUseCase: GetUserProfileUseCase
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(HomeState())
@@ -61,6 +64,13 @@ class HomeViewModel @Inject constructor(
                 _state.update { it.copy(quotes = quotes) }
             }
             .launchIn(viewModelScope)
+
+        viewModelScope.launch {
+            when (val result = getUserProfileUseCase()) {
+                is Result.Success -> _state.update { it.copy(username = result.data.username) }
+                else -> {}
+            }
+        }
 
         refresh()
     }

--- a/app/src/test/java/com/psy/dear/data/repository/FakeUserRepository.kt
+++ b/app/src/test/java/com/psy/dear/data/repository/FakeUserRepository.kt
@@ -1,0 +1,18 @@
+package com.psy.dear.data.repository
+
+import com.psy.dear.core.Result
+import com.psy.dear.domain.model.User
+import com.psy.dear.domain.repository.UserRepository
+
+class FakeUserRepository : UserRepository {
+    var user: User = User("1", "TestUser", "test@example.com")
+    var shouldReturnError = false
+
+    override suspend fun getProfile(): Result<User> {
+        return if (shouldReturnError) {
+            Result.Error(Exception("Profile error"))
+        } else {
+            Result.Success(user)
+        }
+    }
+}

--- a/app/src/test/java/com/psy/dear/presentation/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/psy/dear/presentation/home/HomeViewModelTest.kt
@@ -3,6 +3,7 @@ package com.psy.dear.presentation.home
 import app.cash.turbine.test
 import com.psy.dear.data.repository.FakeJournalRepository
 import com.psy.dear.data.repository.FakeContentRepository
+import com.psy.dear.data.repository.FakeUserRepository
 import com.psy.dear.domain.model.Journal
 import com.psy.dear.domain.model.Article
 import com.psy.dear.core.UiText
@@ -12,6 +13,7 @@ import com.psy.dear.domain.use_case.journal.SyncJournalsUseCase
 import com.psy.dear.domain.use_case.content.GetArticlesUseCase
 import com.psy.dear.domain.use_case.content.GetAudioTracksUseCase
 import com.psy.dear.domain.use_case.content.GetQuotesUseCase
+import com.psy.dear.domain.use_case.user.GetUserProfileUseCase
 import com.psy.dear.util.TestCoroutineRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -33,21 +35,25 @@ class HomeViewModelTest {
     private lateinit var viewModel: HomeViewModel
     private lateinit var fakeRepository: FakeJournalRepository
     private lateinit var fakeContentRepo: FakeContentRepository
+    private lateinit var fakeUserRepo: FakeUserRepository
     private lateinit var getJournalsUseCase: GetJournalsUseCase
     private lateinit var syncJournalsUseCase: SyncJournalsUseCase
     private lateinit var getArticles: GetArticlesUseCase
     private lateinit var getAudio: GetAudioTracksUseCase
     private lateinit var getQuotes: GetQuotesUseCase
+    private lateinit var getUserProfile: GetUserProfileUseCase
 
     @Before
     fun setUp() {
         fakeRepository = FakeJournalRepository()
         fakeContentRepo = FakeContentRepository()
+        fakeUserRepo = FakeUserRepository()
         getJournalsUseCase = GetJournalsUseCase(fakeRepository)
         syncJournalsUseCase = SyncJournalsUseCase(fakeRepository)
         getArticles = GetArticlesUseCase(fakeContentRepo)
         getAudio = GetAudioTracksUseCase(fakeContentRepo)
         getQuotes = GetQuotesUseCase(fakeContentRepo)
+        getUserProfile = GetUserProfileUseCase(fakeUserRepo)
 
         // Tambahkan beberapa data dummy
         fakeRepository.addJournal(Journal("1", "Test 1", "Content 1", "Happy", OffsetDateTime.now()))
@@ -57,7 +63,8 @@ class HomeViewModelTest {
             syncJournalsUseCase,
             getArticles,
             getAudio,
-            getQuotes
+            getQuotes,
+            getUserProfile
         )
     }
 
@@ -70,6 +77,7 @@ class HomeViewModelTest {
             assertEquals("Test 1", initialState.journals[0].title)
             assertFalse(initialState.isLoading)
             assertNull(initialState.error)
+            assertEquals("TestUser", initialState.username)
         }
     }
 


### PR DESCRIPTION
## Summary
- load user profile in `HomeViewModel`
- store username in `HomeState`
- display username in `HomeScreen`
- add `FakeUserRepository` and update unit tests

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a2aa1e8cc8324ae3f675e31b74c78