### PR TITLE
Add press animations to home cards

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/components/PressableCard.kt
+++ b/app/src/main/java/com/psy/dear/presentation/components/PressableCard.kt
@@ -1,0 +1,42 @@
+package com.psy.dear.presentation.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.material3.Card
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+
+@Composable
+fun PressableCard(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed = interactionSource.collectIsPressedAsState()
+    val scale = animateFloatAsState(if (pressed.value) 0.95f else 1f)
+    val alpha = animateFloatAsState(if (pressed.value) 0.9f else 1f)
+
+    Card(
+        modifier = modifier
+            .graphicsLayer {
+                scaleX = scale.value
+                scaleY = scale.value
+                this.alpha = alpha.value
+            }
+            .clickable(
+                interactionSource = interactionSource,
+                indication = rememberRipple(),
+                onClick = onClick
+            )
+    ) {
+        Box(content = content)
+    }
+}

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeCards.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeCards.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.psy.dear.domain.model.*
+import com.psy.dear.presentation.components.PressableCard
 
 @Composable
 fun GreetingCard(userName: String) {
@@ -33,10 +34,13 @@ fun JournalPromptCard(onClick: () -> Unit) {
 }
 
 @Composable
-fun ArticleCard(article: Article) {
-    Card(modifier = Modifier
-        .fillMaxWidth()
-        .padding(horizontal = 16.dp, vertical = 8.dp)) {
+fun ArticleCard(article: Article, onClick: () -> Unit = {}) {
+    PressableCard(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
         Column(Modifier.padding(16.dp)) {
             Text(article.title, style = MaterialTheme.typography.titleMedium)
             Text(article.url, style = MaterialTheme.typography.bodySmall)
@@ -45,10 +49,13 @@ fun ArticleCard(article: Article) {
 }
 
 @Composable
-fun AudioCard(track: AudioTrack) {
-    Card(modifier = Modifier
-        .fillMaxWidth()
-        .padding(horizontal = 16.dp, vertical = 8.dp)) {
+fun AudioCard(track: AudioTrack, onClick: () -> Unit = {}) {
+    PressableCard(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
         Column(Modifier.padding(16.dp)) {
             Text(track.title, style = MaterialTheme.typography.titleMedium)
             Text(track.url, style = MaterialTheme.typography.bodySmall)
@@ -57,10 +64,13 @@ fun AudioCard(track: AudioTrack) {
 }
 
 @Composable
-fun MotivationCard(quote: MotivationalQuote) {
-    Card(modifier = Modifier
-        .fillMaxWidth()
-        .padding(horizontal = 16.dp, vertical = 8.dp)) {
+fun MotivationCard(quote: MotivationalQuote, onClick: () -> Unit = {}) {
+    PressableCard(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
         Column(Modifier.padding(16.dp)) {
             Text("\"${quote.text}\"", style = MaterialTheme.typography.bodyMedium)
             Text("- ${quote.author}", style = MaterialTheme.typography.bodySmall)

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
@@ -1,6 +1,5 @@
 package com.psy.dear.presentation.home
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -20,6 +19,7 @@ import com.psy.dear.domain.model.Journal
 import com.psy.dear.core.asString
 import com.psy.dear.presentation.components.FullScreenLoading
 import com.psy.dear.presentation.components.InfoMessage
+import com.psy.dear.presentation.components.PressableCard
 import com.psy.dear.presentation.home.ArticleCard
 import com.psy.dear.presentation.home.AudioCard
 import com.psy.dear.presentation.home.GreetingCard
@@ -73,11 +73,11 @@ fun HomeScreen(
 
 @Composable
 fun JournalItem(journal: Journal, onClick: () -> Unit) {
-    Card(
+    PressableCard(
+        onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp)
-            .clickable(onClick = onClick)
     ) {
         Column(Modifier.padding(16.dp)) {
             Text(text = journal.title, style = MaterialTheme.typography.titleLarge)


### PR DESCRIPTION
## Summary
- create `PressableCard` composable with animated scale and opacity
- use `PressableCard` in `JournalItem`, `ArticleCard`, `AudioCard` and `MotivationCard`

## Testing
- `./gradlew --version` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685a2f6936908324b635c5d4d39c4b83