### PR TITLE
Fix card shapes on home screen

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/home/HomeCards.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeCards.kt
@@ -14,7 +14,7 @@ import com.psy.dear.presentation.components.PressableCard
 
 @Composable
 fun GreetingCard(userName: String) {
-    val shape = RoundedCornerShape(20.dp)
+    val shape = RoundedCornerShape(16.dp)
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -50,7 +50,7 @@ fun GreetingCard(userName: String) {
 
 @Composable
 fun JournalPromptCard(onClick: () -> Unit) {
-    val shape = RoundedCornerShape(20.dp)
+    val shape = RoundedCornerShape(16.dp)
     Card(
         modifier = Modifier
             .fillMaxWidth()


### PR DESCRIPTION
## Summary
- update card corner radius to 16dp for home cards

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a315937f08324bd8c91264a081ab0