### PR TITLE
Switch to outlined icons and apply palette colors

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/chat/ChatScreen.kt
@@ -13,8 +13,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -140,14 +140,14 @@ fun ChatTopBar(
         navigationIcon = {
             if (selectionMode) {
                 IconButton(onClick = onBack) {
-                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    Icon(Icons.Outlined.ArrowBack, contentDescription = "Back")
                 }
             }
         },
         actions = {
             if (selectionMode) {
                 IconButton(onClick = onDelete) {
-                    Icon(Icons.Default.Delete, contentDescription = "Delete")
+                    Icon(Icons.Outlined.Delete, contentDescription = "Delete")
                 }
             }
         }

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
@@ -5,8 +5,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.CloudOff
 import androidx.compose.material.pullrefresh.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -43,7 +43,7 @@ fun HomeScreen(
             FloatingActionButton(onClick = {
                 navController.navigate(Screen.JournalEditor.createRoute(null))
             }) {
-                Icon(Icons.Default.Add, contentDescription = "Entri Baru")
+                Icon(Icons.Outlined.Add, contentDescription = "Entri Baru")
             }
         }
     ) { padding ->
@@ -52,7 +52,7 @@ fun HomeScreen(
             if (state.isLoading && state.journals.isEmpty()) {
                 FullScreenLoading()
             } else {
-                error?.let { InfoMessage(message = it.asString(), icon = Icons.Default.CloudOff) } ?: LazyColumn(modifier = Modifier.fillMaxSize()) {
+                error?.let { InfoMessage(message = it.asString(), icon = Icons.Outlined.CloudOff) } ?: LazyColumn(modifier = Modifier.fillMaxSize()) {
                     item { GreetingCard(state.username) }
                     item { JournalPromptCard { navController.navigate(Screen.JournalEditor.createRoute(null)) } }
                     items(state.articles) { ArticleCard(it) }

--- a/app/src/main/java/com/psy/dear/presentation/journal_detail/JournalDetailScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/journal_detail/JournalDetailScreen.kt
@@ -4,9 +4,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -62,17 +62,17 @@ fun JournalDetailScreen(
                 title = { Text(journal?.title ?: "Detail") },
                 navigationIcon = {
                     IconButton(onClick = { navController.navigateUp() }) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Kembali")
+                        Icon(Icons.Outlined.ArrowBack, contentDescription = "Kembali")
                     }
                 },
                 actions = {
                     IconButton(onClick = {
                         navController.navigate(Screen.JournalEditor.createRoute(journal?.id))
                     }) {
-                        Icon(Icons.Default.Edit, contentDescription = "Edit")
+                        Icon(Icons.Outlined.Edit, contentDescription = "Edit")
                     }
                     IconButton(onClick = { showDeleteDialog = true }) {
-                        Icon(Icons.Default.Delete, contentDescription = "Hapus")
+                        Icon(Icons.Outlined.Delete, contentDescription = "Hapus")
                     }
                 }
             )

--- a/app/src/main/java/com/psy/dear/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/main/MainScreen.kt
@@ -16,6 +16,8 @@ import com.psy.dear.presentation.journal_detail.JournalDetailScreen
 import com.psy.dear.presentation.navigation.Screen
 import com.psy.dear.presentation.profile.ProfileScreen
 import com.psy.dear.presentation.services.ServicesScreen
+import com.psy.dear.ui.theme.DigitalPrimary
+import com.psy.dear.ui.theme.SubtleText
 
 val mainScreens = listOf(Screen.Home, Screen.Chat, Screen.Growth, Screen.Services, Screen.Profile)
 
@@ -39,7 +41,13 @@ fun MainScreen(rootNavController: NavHostController) {
                                 launchSingleTop = true
                                 restoreState = true
                             }
-                        }
+                        },
+                        colors = NavigationBarItemDefaults.colors(
+                            selectedIconColor = DigitalPrimary,
+                            selectedTextColor = DigitalPrimary,
+                            unselectedIconColor = SubtleText,
+                            unselectedTextColor = SubtleText
+                        )
                     )
                 }
             }

--- a/app/src/main/java/com/psy/dear/presentation/navigation/Navigation.kt
+++ b/app/src/main/java/com/psy/dear/presentation/navigation/Navigation.kt
@@ -2,7 +2,7 @@ package com.psy.dear.presentation.navigation
 
 import androidx.compose.animation.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavHostController
@@ -26,11 +26,11 @@ sealed class Screen(val route: String, val title: String? = null, val icon: Imag
     object Login : Screen("login")
     object Register : Screen("register")
 
-    object Home : Screen("home", "Beranda", Icons.Default.Home)
-    object Chat : Screen("chat", "Chat", Icons.Default.ChatBubble)
-    object Growth : Screen("growth", "Pertumbuhan", Icons.Default.ShowChart)
-    object Services : Screen("services", "Layanan", Icons.Default.Favorite)
-    object Profile : Screen("profile", "Profil", Icons.Default.Person)
+    object Home : Screen("home", "Beranda", Icons.Outlined.Home)
+    object Chat : Screen("chat", "Chat", Icons.Outlined.ChatBubbleOutline)
+    object Growth : Screen("growth", "Pertumbuhan", Icons.Outlined.ShowChart)
+    object Services : Screen("services", "Layanan", Icons.Outlined.FavoriteBorder)
+    object Profile : Screen("profile", "Profil", Icons.Outlined.PersonOutline)
 
     object JournalEditor : Screen("journal_editor?journalId={journalId}") {
         fun createRoute(journalId: String?): String = "journal_editor?journalId=$journalId"

--- a/app/src/main/java/com/psy/dear/ui/theme/Color.kt
+++ b/app/src/main/java/com/psy/dear/ui/theme/Color.kt
@@ -17,6 +17,9 @@ val OtherBubble = Color(0xFFFFFFFF)
 val ChatAppBar = Color(0xFF075E54)
 val IconInactive = Color(0xFFAAB8B8)
 
+// Neutral text/icon color for inactive states
+val SubtleText = Color(0xFFAAB8B8)
+
 // Digital theme colors
 val DigitalBackground = Color(0xFF101010)
 val DigitalSurface = Color(0xFF1E1E1E)


### PR DESCRIPTION
## Summary
- swap `Icons.Default` usages for outline versions across screens
- add `SubtleText` color
- apply new icon palette in bottom navigation

## Testing
- `gradle test` *(fails: SDK location not found)*
- `pytest backend/tests` *(fails: test_services_handle_invalid_credentials)*

------
https://chatgpt.com/codex/tasks/task_e_685a32af9e148324a24005fd2ad671eb