### PR TITLE
Fix flagging endpoint mismatch

### DIFF
--- a/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
+++ b/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
@@ -24,7 +24,7 @@ interface ChatApiService {
     @DELETE("chat/{id}")
     suspend fun deleteMessage(@Path("id") id: String)
 
-    @POST("chat/{id}/flag")
+    @PATCH("chat/{id}/flag")
     suspend fun setFlag(
         @Path("id") id: String,
         @Body request: FlagRequest

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -103,3 +103,10 @@ def test_flag_and_delete_message(client):
 
     app.dependency_overrides.pop(PlannerService, None)
     app.dependency_overrides.pop(GeneratorService, None)
+
+
+def test_flag_missing_message_returns_404(client):
+    client_app, _ = client
+
+    response = client_app.patch("/api/v1/chat/9999/flag", json={"flag": True})
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- align Android Retrofit API with the backend by using PATCH for chat flagging
- test flagging a non-existent message returns 404

## Testing
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_685a6581f6448324bd26fab86611368e