### PR TITLE
Add database seeding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+# Simple helper targets for backend development
+
+.PHONY: seed
+
+seed:
+	cd backend && python -m app.db.seed

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ alembic revision --autogenerate -m "<description>"
 # apply migrations
 alembic upgrade head
 ```
+### Loading Sample Data
+
+After applying migrations you can populate some example articles, audio tracks and motivational quotes. Run:
+
+```bash
+make seed
+```
+
 
 ### Environment Variables
 

--- a/backend/app/db/seed.py
+++ b/backend/app/db/seed.py
@@ -1,0 +1,39 @@
+"""Populate the database with some initial data."""
+
+from app.db.session import SessionLocal
+from app import crud, schemas
+
+
+ARTICLES = [
+    {"title": "Mindfulness Basics", "url": "https://example.com/mindfulness"},
+    {"title": "Dealing with Stress", "url": "https://example.com/stress"},
+]
+
+AUDIO_TRACKS = [
+    {"title": "Relaxing Piano", "url": "https://example.com/audio/piano.mp3"},
+    {"title": "Nature Sounds", "url": "https://example.com/audio/nature.mp3"},
+]
+
+QUOTES = [
+    {"text": "Keep going no matter what.", "author": "Unknown"},
+    {"text": "Every day is a fresh start.", "author": "Unknown"},
+]
+
+
+def seed() -> None:
+    db = SessionLocal()
+    try:
+        for data in ARTICLES:
+            crud.article.create(db, obj_in=schemas.ArticleCreate(**data))
+
+        for data in AUDIO_TRACKS:
+            crud.audio_track.create(db, obj_in=schemas.AudioTrackCreate(**data))
+
+        for data in QUOTES:
+            crud.motivational_quote.create(db, obj_in=schemas.MotivationalQuoteCreate(**data))
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    seed()


### PR DESCRIPTION
## Summary
- provide new seed.py to populate Articles, AudioTracks and MotivationalQuotes
- add `seed` target in Makefile
- document how to run the seeder in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_685a74e6155083249d438a8e7fd1506e