### PR TITLE
Update test instructions and add make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # Simple helper targets for backend development
 
-.PHONY: seed
+.PHONY: seed test
 
 seed:
 	cd backend && python -m app.db.seed
+
+test:
+	pip install -r backend/requirements.txt pytest pytest-asyncio
+	pytest backend/tests

--- a/README.md
+++ b/README.md
@@ -133,11 +133,20 @@ The chat endpoint performs a basic emotion analysis on each message. The detecte
 
 ## Running Tests
 
+Install the backend dependencies first; the tests require the packages listed in `backend/requirements.txt`:
+
 ```bash
 pip install -r backend/requirements.txt
 pip install pytest pytest-asyncio
+```
+
+Run the suite with:
+
+```bash
 pytest backend/tests
 ```
+
+Alternatively you can simply run `make test` which installs the requirements and executes `pytest` for you.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- clarify test setup requirements in README
- add `make test` target to automate dependency install and running pytest

## Testing
- `pip install -r backend/requirements.txt`
- `pip install pytest`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_685a7eec0cc88324b0872ef60fc2be6c