### PR TITLE
Add audio playback logic

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/content/AudioPlayerScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/content/AudioPlayerScreen.kt
@@ -10,22 +10,56 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import android.media.MediaPlayer
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.psy.dear.presentation.home.HomeViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AudioPlayerScreen(
     navController: NavController,
     trackTitle: String,
-    trackUrl: String // kita akan gunakan ini nanti
+    trackUrl: String, // kita akan gunakan ini nanti
+    homeViewModel: HomeViewModel = hiltViewModel()
 ) {
+    val state by homeViewModel.state.collectAsState()
+    val tracks = state.audio
+    var currentIndex by remember(tracks, trackUrl) {
+        mutableStateOf(tracks.indexOfFirst { it.url == trackUrl }.takeIf { it >= 0 } ?: 0)
+    }
+    var isPlaying by remember { mutableStateOf(false) }
+    val mediaPlayer = remember { MediaPlayer() }
+
+    DisposableEffect(currentIndex, tracks) {
+        val track = tracks.getOrNull(currentIndex)
+        if (track != null) {
+            try {
+                mediaPlayer.reset()
+                mediaPlayer.setDataSource(track.url)
+                mediaPlayer.prepare()
+                if (isPlaying) mediaPlayer.start()
+                mediaPlayer.setOnCompletionListener {
+                    if (tracks.isNotEmpty()) {
+                        currentIndex = (currentIndex + 1) % tracks.size
+                        isPlaying = true
+                    }
+                }
+            } catch (_: Exception) {
+            }
+        }
+        onDispose { }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { mediaPlayer.release() }
+    }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -61,7 +95,7 @@ fun AudioPlayerScreen(
 
             // Judul Lagu
             Text(
-                text = trackTitle,
+                text = tracks.getOrNull(currentIndex)?.title ?: trackTitle,
                 style = MaterialTheme.typography.headlineSmall,
                 textAlign = TextAlign.Center
             )
@@ -81,13 +115,35 @@ fun AudioPlayerScreen(
                 horizontalArrangement = Arrangement.SpaceEvenly,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                IconButton(onClick = { /*TODO*/ }) {
+                IconButton(onClick = {
+                    if (tracks.isNotEmpty()) {
+                        currentIndex = if (currentIndex - 1 < 0) tracks.size - 1 else currentIndex - 1
+                        isPlaying = true
+                    }
+                }) {
                     Icon(Icons.Default.SkipPrevious, contentDescription = "Sebelumnya", modifier = Modifier.size(48.dp))
                 }
-                IconButton(onClick = { /*TODO*/ }, modifier = Modifier.size(72.dp)) {
-                    Icon(Icons.Default.PlayArrow, contentDescription = "Play", modifier = Modifier.fillMaxSize())
+                IconButton(onClick = {
+                    if (mediaPlayer.isPlaying) {
+                        mediaPlayer.pause()
+                        isPlaying = false
+                    } else {
+                        mediaPlayer.start()
+                        isPlaying = true
+                    }
+                }, modifier = Modifier.size(72.dp)) {
+                    Icon(
+                        if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        contentDescription = if (isPlaying) "Pause" else "Play",
+                        modifier = Modifier.fillMaxSize()
+                    )
                 }
-                IconButton(onClick = { /*TODO*/ }) {
+                IconButton(onClick = {
+                    if (tracks.isNotEmpty()) {
+                        currentIndex = (currentIndex + 1) % tracks.size
+                        isPlaying = true
+                    }
+                }) {
                     Icon(Icons.Default.SkipNext, contentDescription = "Berikutnya", modifier = Modifier.size(48.dp))
                 }
             }


### PR DESCRIPTION
## Summary
- implement a simple audio player using `MediaPlayer`
- handle play/pause and track navigation

## Testing
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_685bdbd888948324b64d964d94eae307