### PR TITLE
Add YouTube Music search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ pip install -r backend/requirements.txt
 cd backend && uvicorn app.main:app --reload
 ```
 
+Once running you can try the music search endpoint:
+
+```bash
+curl "http://localhost:8000/api/v1/music?mood=happy"
+```
+
 ### Database Migrations
 
 Alembic handles schema migrations. Common commands:

--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.api.v1 import auth, journal, chat, user, article, audio, quote, home
+from app.api.v1 import auth, journal, chat, user, article, audio, quote, home, music
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
@@ -10,4 +10,5 @@ api_router.include_router(article.router, prefix="/articles", tags=["articles"])
 api_router.include_router(audio.router, prefix="/audio", tags=["audio"])
 api_router.include_router(quote.router, prefix="/quotes", tags=["quotes"])
 api_router.include_router(home.router, tags=["home"])
+api_router.include_router(music.router, prefix="/music", tags=["music"])
 

--- a/backend/app/api/v1/music.py
+++ b/backend/app/api/v1/music.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Query
+from ytmusicapi import YTMusic
+from app import schemas
+
+router = APIRouter()
+
+@router.get("/", response_model=list[schemas.AudioTrack])
+def search_music(mood: str = Query(..., min_length=1)):
+    results = YTMusic().search(mood, filter="songs")
+    tracks = []
+    for idx, item in enumerate(results):
+        title = item.get("title")
+        video_id = item.get("videoId")
+        if not title or not video_id:
+            continue
+        url = f"https://music.youtube.com/watch?v={video_id}"
+        tracks.append(schemas.AudioTrack(id=idx + 1, title=title, url=url))
+    return tracks

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,7 @@ uvicorn
 httpx>=0.27.0
 structlog>=24.1.0
 email-validator
+ytmusicapi
 
 # Testing
 pytest-asyncio

--- a/backend/tests/test_music_api.py
+++ b/backend/tests/test_music_api.py
@@ -1,0 +1,15 @@
+from ytmusicapi import YTMusic
+
+
+def test_music_endpoint_returns_list(client, monkeypatch):
+    def fake_search(self, query, filter="songs", limit=20):
+        return [{"title": "Song", "videoId": "abc123"}]
+
+    monkeypatch.setattr(YTMusic, "search", fake_search)
+
+    client_app, _ = client
+    resp = client_app.get("/api/v1/music?mood=test")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert data[0]["url"].endswith("abc123")


### PR DESCRIPTION
## Summary
- add `ytmusicapi` to backend requirements
- implement `/music` API router backed by YouTube Music search
- integrate the new router
- test the new endpoint
- document how to use the music search in the README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_685c0d5874b883248382595df1371123