### PR TITLE
Implement mood-based music recommendations

### DIFF
--- a/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
+++ b/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
@@ -43,6 +43,9 @@ interface ContentApiService {
     @GET("audio")
     suspend fun getAudio(): List<AudioTrackResponse>
 
+    @GET("music")
+    suspend fun getMoodMusic(@Query("mood") mood: String): List<AudioTrackResponse>
+
     @GET("quotes")
     suspend fun getQuotes(): List<MotivationalQuoteResponse>
 }

--- a/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
@@ -171,6 +171,10 @@ class ContentRepositoryImpl @Inject constructor(
         emit(api.getAudio().map { it.toDomain() })
     }
 
+    override fun getMoodMusic(mood: String): Flow<List<AudioTrack>> = flow {
+        emit(api.getMoodMusic(mood).map { it.toDomain() })
+    }
+
     override fun getQuotes(): Flow<List<MotivationalQuote>> = flow {
         emit(api.getQuotes().map { it.toDomain() })
     }

--- a/app/src/main/java/com/psy/dear/domain/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/domain/repository/Repositories.kt
@@ -35,5 +35,6 @@ interface ChatRepository {
 interface ContentRepository {
     fun getArticles(): Flow<List<Article>>
     fun getAudioTracks(): Flow<List<AudioTrack>>
+    fun getMoodMusic(mood: String): Flow<List<AudioTrack>>
     fun getQuotes(): Flow<List<MotivationalQuote>>
 }

--- a/app/src/main/java/com/psy/dear/domain/use_case/content/UseCases.kt
+++ b/app/src/main/java/com/psy/dear/domain/use_case/content/UseCases.kt
@@ -15,6 +15,10 @@ class GetAudioTracksUseCase @Inject constructor(private val repo: ContentReposit
     operator fun invoke(): Flow<List<AudioTrack>> = repo.getAudioTracks()
 }
 
+class GetMoodMusicUseCase @Inject constructor(private val repo: ContentRepository) {
+    operator fun invoke(mood: String): Flow<List<AudioTrack>> = repo.getMoodMusic(mood)
+}
+
 class GetQuotesUseCase @Inject constructor(private val repo: ContentRepository) {
     operator fun invoke(): Flow<List<MotivationalQuote>> = repo.getQuotes()
 }

--- a/app/src/main/java/com/psy/dear/presentation/content/AudioPlayerScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/content/AudioPlayerScreen.kt
@@ -30,7 +30,7 @@ fun AudioPlayerScreen(
     homeViewModel: HomeViewModel = hiltViewModel()
 ) {
     val state by homeViewModel.state.collectAsState()
-    val tracks = state.audio
+    val tracks = state.audio + state.moodTracks
     var currentIndex by remember(tracks, trackUrl) {
         mutableStateOf(tracks.indexOfFirst { it.url == trackUrl }.takeIf { it >= 0 } ?: 0)
     }

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeCards.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeCards.kt
@@ -128,6 +128,33 @@ fun AudioCard(track: AudioTrack, modifier: Modifier = Modifier, onClick: () -> U
 }
 
 @Composable
+fun MoodMusicCard(track: AudioTrack, modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
+    Card(
+        onClick = onClick,
+        modifier = modifier
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.GraphicEq,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(32.dp)
+            )
+            Spacer(Modifier.width(12.dp))
+            Column {
+                Text(track.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                Text(track.url, style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}
+
+@Composable
 fun MotivationCard(quote: MotivationalQuote, modifier: Modifier = Modifier) {
     Card(
         modifier = modifier.fillMaxWidth(),

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
@@ -82,6 +82,23 @@ private fun HomeDashboard(state: HomeState, navController: NavController) {
         item { GreetingCard(userName = state.username) }
         item { JournalPromptCard { navController.navigate(Screen.JournalEditor.createRoute(null)) } }
 
+        if (state.moodTracks.isNotEmpty()) {
+            item {
+                MoodMusicCard(
+                    track = state.moodTracks.first(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    onClick = {
+                        val track = state.moodTracks.first()
+                        navController.navigate(
+                            Screen.AudioPlayer.createRoute(url = track.url, title = track.title)
+                        )
+                    }
+                )
+            }
+        }
+
         if (state.quotes.isNotEmpty()) {
             item {
                 SectionHeader(title = "Kutipan Hari Ini", modifier = Modifier.padding(top = 16.dp))

--- a/app/src/test/java/com/psy/dear/data/repository/FakeContentRepository.kt
+++ b/app/src/test/java/com/psy/dear/data/repository/FakeContentRepository.kt
@@ -11,13 +11,16 @@ import kotlinx.coroutines.flow.asStateFlow
 class FakeContentRepository : ContentRepository {
     private val articlesFlow = MutableStateFlow<List<Article>>(emptyList())
     private val audioFlow = MutableStateFlow<List<AudioTrack>>(emptyList())
+    private val moodMusicFlow = MutableStateFlow<List<AudioTrack>>(emptyList())
     private val quotesFlow = MutableStateFlow<List<MotivationalQuote>>(emptyList())
 
     fun setArticles(list: List<Article>) { articlesFlow.value = list }
     fun setAudio(list: List<AudioTrack>) { audioFlow.value = list }
+    fun setMoodMusic(list: List<AudioTrack>) { moodMusicFlow.value = list }
     fun setQuotes(list: List<MotivationalQuote>) { quotesFlow.value = list }
 
     override fun getArticles(): Flow<List<Article>> = articlesFlow.asStateFlow()
     override fun getAudioTracks(): Flow<List<AudioTrack>> = audioFlow.asStateFlow()
+    override fun getMoodMusic(mood: String): Flow<List<AudioTrack>> = moodMusicFlow.asStateFlow()
     override fun getQuotes(): Flow<List<MotivationalQuote>> = quotesFlow.asStateFlow()
 }

--- a/app/src/test/java/com/psy/dear/presentation/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/psy/dear/presentation/home/HomeViewModelTest.kt
@@ -12,6 +12,7 @@ import com.psy.dear.domain.use_case.journal.GetJournalsUseCase
 import com.psy.dear.domain.use_case.journal.SyncJournalsUseCase
 import com.psy.dear.domain.use_case.content.GetArticlesUseCase
 import com.psy.dear.domain.use_case.content.GetAudioTracksUseCase
+import com.psy.dear.domain.use_case.content.GetMoodMusicUseCase
 import com.psy.dear.domain.use_case.content.GetQuotesUseCase
 import com.psy.dear.domain.use_case.user.GetUserProfileUseCase
 import com.psy.dear.util.TestCoroutineRule
@@ -41,6 +42,7 @@ class HomeViewModelTest {
     private lateinit var syncJournalsUseCase: SyncJournalsUseCase
     private lateinit var getArticles: GetArticlesUseCase
     private lateinit var getAudio: GetAudioTracksUseCase
+    private lateinit var getMoodMusic: GetMoodMusicUseCase
     private lateinit var getQuotes: GetQuotesUseCase
     private lateinit var getUserProfile: GetUserProfileUseCase
 
@@ -53,6 +55,7 @@ class HomeViewModelTest {
         syncJournalsUseCase = SyncJournalsUseCase(fakeRepository)
         getArticles = GetArticlesUseCase(fakeContentRepo)
         getAudio = GetAudioTracksUseCase(fakeContentRepo)
+        getMoodMusic = GetMoodMusicUseCase(fakeContentRepo)
         getQuotes = GetQuotesUseCase(fakeContentRepo)
         getUserProfile = GetUserProfileUseCase(fakeUserRepo)
 
@@ -64,6 +67,7 @@ class HomeViewModelTest {
             syncJournalsUseCase,
             getArticles,
             getAudio,
+            getMoodMusic,
             getQuotes,
             getUserProfile
         )


### PR DESCRIPTION
## Summary
- add mood-based music API call in `ContentApiService`
- extend repository & fake repository for mood music
- implement `GetMoodMusicUseCase`
- support mood music in `HomeViewModel` and state
- display a `MoodMusicCard` on the home screen
- combine mood tracks in `AudioPlayerScreen`
- update tests for new use case

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685c0f9e48c0832482fe4177e146ea05