### PR TITLE
Fix import path for music router

### DIFF
--- a/backend/app/api/v1/music.py
+++ b/backend/app/api/v1/music.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from ytmusicapi import YTMusic
-from ..deps import get_current_active_user
+from app.dependencies import get_current_user
 from app.models.user import User
 import yt_dlp
 from app import schemas
@@ -13,7 +13,7 @@ ytmusic = YTMusic()
 @router.get("/", response_model=list[schemas.AudioTrack])
 def search_music(
     mood: str = Query(..., min_length=1),
-    current_user: User = Depends(get_current_active_user)
+    current_user: User = Depends(get_current_user)
 ):
     if not mood:
         raise HTTPException(status_code=400, detail="Mood parameter is required")


### PR DESCRIPTION
## Summary
- fix broken import for `music` API router

## Testing
- `make test` *(fails: test_music_api.py::test_music_endpoint_returns_list)*

------
https://chatgpt.com/codex/tasks/task_e_685c1f7e7e948324bc5336c4ae678ec9