### PR TITLE
Fix mood music playback with ytmusicapi

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,6 @@ httpx>=0.27.0
 structlog>=24.1.0
 email-validator
 ytmusicapi
-yt-dlp
 
 # Testing
 pytest-asyncio

--- a/backend/tests/test_music_api.py
+++ b/backend/tests/test_music_api.py
@@ -5,11 +5,21 @@ def test_music_endpoint_returns_list(client, monkeypatch):
     def fake_search(self, query, filter="songs", limit=20):
         return [{"title": "Song", "videoId": "abc123"}]
 
+    def fake_get_song(self, videoId):
+        return {
+            "streamingData": {
+                "adaptiveFormats": [
+                    {"url": "https://audio.example/abc123.m4a", "mimeType": "audio/mp4"}
+                ]
+            }
+        }
+
     monkeypatch.setattr(YTMusic, "search", fake_search)
+    monkeypatch.setattr(YTMusic, "get_song", fake_get_song)
 
     client_app, _ = client
     resp = client_app.get("/api/v1/music?mood=test")
     assert resp.status_code == 200
     data = resp.json()
     assert isinstance(data, list)
-    assert data[0]["url"].endswith("abc123")
+    assert data[0]["url"] == "https://audio.example/abc123.m4a"


### PR DESCRIPTION
## Summary
- fetch mood-based streaming URLs directly with `ytmusicapi`
- remove `yt-dlp` dependency
- update tests to mock `get_song` responses

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c24616e148324b7ba6a1370161b5e