### PR TITLE
Handle missing music results

### DIFF
--- a/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
@@ -172,7 +172,15 @@ class ContentRepositoryImpl @Inject constructor(
     }
 
     override fun getMoodMusic(mood: String): Flow<List<AudioTrack>> = flow {
-        emit(api.getMoodMusic(mood).map { it.toDomain() })
+        try {
+            emit(api.getMoodMusic(mood).map { it.toDomain() })
+        } catch (e: HttpException) {
+            if (e.code() == 404) {
+                emit(emptyList())
+            } else {
+                throw e
+            }
+        }
     }
 
     override fun getQuotes(): Flow<List<MotivationalQuote>> = flow {


### PR DESCRIPTION
## Summary
- catch `HttpException` when fetching mood-based music
- return an empty list if the backend responds with 404

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c2676e90c83248ddbc8d8028e736f