### PR TITLE
Add music recommendation endpoint

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
-from app.api.v1 import auth, journal, chat, user, article, audio, quote, home, music
+from app.api.v1 import auth, journal, chat, user, article, audio, quote, home
+from app.api.v1.music import router as music_router
 
 api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
@@ -10,5 +11,5 @@ api_router.include_router(article.router, prefix="/articles", tags=["articles"])
 api_router.include_router(audio.router, prefix="/audio", tags=["audio"])
 api_router.include_router(quote.router, prefix="/quotes", tags=["quotes"])
 api_router.include_router(home.router, tags=["home"])
-api_router.include_router(music.router, prefix="/music", tags=["music"])
+api_router.include_router(music_router, prefix="/music", tags=["music"])
 

--- a/backend/app/api/v1/music.py
+++ b/backend/app/api/v1/music.py
@@ -1,10 +1,11 @@
 # app/api/v1/endpoints/music.py
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
 from ytmusicapi import YTMusic
-from app.dependencies import get_current_user
-from app.models.user import User
-from app import schemas
+
+from app import crud, models, schemas, dependencies
+from app.services.music_keyword_service import MusicKeywordService
 
 router = APIRouter()
 ytmusic = YTMusic()
@@ -12,7 +13,7 @@ ytmusic = YTMusic()
 @router.get("/", response_model=list[schemas.AudioTrack])
 def search_music(
     mood: str = Query(..., min_length=1),
-    current_user: User = Depends(get_current_user)
+    current_user: models.User = Depends(dependencies.get_current_user)
 ):
     if not mood:
         raise HTTPException(status_code=400, detail="Mood parameter is required")
@@ -49,5 +50,49 @@ def search_music(
 
     if not musics:
         raise HTTPException(status_code=404, detail="No music found for the given mood")
+
+    return musics
+
+
+@router.get("/recommend", response_model=list[schemas.AudioTrack])
+async def recommend_music(
+    *,
+    db: Session = Depends(dependencies.get_db),
+    current_user: models.User = Depends(dependencies.get_current_user),
+    keyword_service: MusicKeywordService = Depends(),
+):
+    journals = crud.journal.get_multi_by_owner(
+        db=db,
+        owner_id=current_user.id,
+        limit=5,
+    )
+    keyword = await keyword_service.generate_keyword(journals)
+
+    search_results = ytmusic.search(query=keyword, filter="songs", limit=20)
+
+    musics: list[schemas.AudioTrack] = []
+    for idx, track in enumerate(search_results, start=1):
+        video_id = track.get("videoId")
+        title = track.get("title")
+        if not video_id or not title:
+            continue
+
+        try:
+            song = ytmusic.get_song(video_id)
+            formats = song.get("streamingData", {}).get("adaptiveFormats", [])
+            audio_format = next(
+                (f for f in formats if f.get("mimeType", "").startswith("audio/")),
+                None,
+            )
+            streaming_url = audio_format.get("url") if audio_format else None
+        except Exception as e:
+            print(f"Could not process video {video_id}: {e}")
+            continue
+
+        if streaming_url:
+            musics.append(schemas.AudioTrack(id=idx, title=title, url=streaming_url))
+
+    if not musics:
+        raise HTTPException(status_code=404, detail="No music found")
 
     return musics

--- a/backend/tests/test_music_api.py
+++ b/backend/tests/test_music_api.py
@@ -1,4 +1,7 @@
 from ytmusicapi import YTMusic
+from app import crud
+from app.services.music_keyword_service import MusicKeywordService
+from app.models.journal import Journal
 
 
 def test_music_endpoint_returns_list(client, monkeypatch):
@@ -23,3 +26,44 @@ def test_music_endpoint_returns_list(client, monkeypatch):
     data = resp.json()
     assert isinstance(data, list)
     assert data[0]["url"] == "https://audio.example/abc123.m4a"
+
+
+def test_music_recommend_uses_keyword_and_journals(client, monkeypatch):
+    captured = {}
+
+    def fake_get_multi_by_owner(db, owner_id: int, skip: int = 0, limit: int = 100):
+        captured["limit"] = limit
+        return [Journal(content=f"j{i}") for i in range(3)]
+
+    async def fake_generate_keyword(self, journals):
+        captured["journals"] = journals
+        return "lofi"
+
+    def fake_search(self, query, filter="songs", limit=20):
+        captured["query"] = query
+        return [{"title": "Song", "videoId": "xyz"}]
+
+    def fake_get_song(self, videoId):
+        return {
+            "streamingData": {
+                "adaptiveFormats": [
+                    {"url": "https://audio.example/xyz.m4a", "mimeType": "audio/mp4"}
+                ]
+            }
+        }
+
+    monkeypatch.setattr(crud.journal, "get_multi_by_owner", fake_get_multi_by_owner)
+    monkeypatch.setattr(MusicKeywordService, "generate_keyword", fake_generate_keyword)
+    monkeypatch.setattr(YTMusic, "search", fake_search)
+    monkeypatch.setattr(YTMusic, "get_song", fake_get_song)
+
+    client_app, _ = client
+    resp = client_app.get("/api/v1/music/recommend")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["url"] == "https://audio.example/xyz.m4a"
+    assert captured["limit"] == 5
+    assert len(captured["journals"]) == 3
+    assert captured["query"] == "lofi"
+


### PR DESCRIPTION
## Summary
- inject `MusicKeywordService` in music API
- add `/recommend` music route using recent journals
- import `music_router` in API setup
- extend music API tests to cover recommendations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c31b6c6908324b11ad45cc3f27cb6