### PR TITLE
Implement recommended music API

### DIFF
--- a/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
+++ b/app/src/main/java/com/psy/dear/data/network/api/ApiServices.kt
@@ -46,6 +46,9 @@ interface ContentApiService {
     @GET("music")
     suspend fun getMoodMusic(@Query("mood") mood: String): List<AudioTrackResponse>
 
+    @GET("music/recommend")
+    suspend fun getRecommendedMusic(): List<AudioTrackResponse>
+
     @GET("quotes")
     suspend fun getQuotes(): List<MotivationalQuoteResponse>
 }

--- a/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/data/repository/Repositories.kt
@@ -183,6 +183,18 @@ class ContentRepositoryImpl @Inject constructor(
         }
     }
 
+    override fun getRecommendedMusic(): Flow<List<AudioTrack>> = flow {
+        try {
+            emit(api.getRecommendedMusic().map { it.toDomain() })
+        } catch (e: HttpException) {
+            if (e.code() == 404) {
+                emit(emptyList())
+            } else {
+                throw e
+            }
+        }
+    }
+
     override fun getQuotes(): Flow<List<MotivationalQuote>> = flow {
         emit(api.getQuotes().map { it.toDomain() })
     }

--- a/app/src/main/java/com/psy/dear/domain/repository/Repositories.kt
+++ b/app/src/main/java/com/psy/dear/domain/repository/Repositories.kt
@@ -36,5 +36,6 @@ interface ContentRepository {
     fun getArticles(): Flow<List<Article>>
     fun getAudioTracks(): Flow<List<AudioTrack>>
     fun getMoodMusic(mood: String): Flow<List<AudioTrack>>
+    fun getRecommendedMusic(): Flow<List<AudioTrack>>
     fun getQuotes(): Flow<List<MotivationalQuote>>
 }

--- a/app/src/main/java/com/psy/dear/domain/use_case/content/UseCases.kt
+++ b/app/src/main/java/com/psy/dear/domain/use_case/content/UseCases.kt
@@ -19,6 +19,10 @@ class GetMoodMusicUseCase @Inject constructor(private val repo: ContentRepositor
     operator fun invoke(mood: String): Flow<List<AudioTrack>> = repo.getMoodMusic(mood)
 }
 
+class GetRecommendedMusicUseCase @Inject constructor(private val repo: ContentRepository) {
+    operator fun invoke(): Flow<List<AudioTrack>> = repo.getRecommendedMusic()
+}
+
 class GetQuotesUseCase @Inject constructor(private val repo: ContentRepository) {
     operator fun invoke(): Flow<List<MotivationalQuote>> = repo.getQuotes()
 }

--- a/app/src/test/java/com/psy/dear/data/repository/ContentRepositoryImplTest.kt
+++ b/app/src/test/java/com/psy/dear/data/repository/ContentRepositoryImplTest.kt
@@ -42,4 +42,22 @@ class ContentRepositoryImplTest {
 
         assertEquals(expected, result)
     }
+
+    @Test
+    fun `getRecommendedMusic emits tracks from api as domain models`() = runTest {
+        val responses = listOf(
+            AudioTrackResponse("1", "Track1", "url1"),
+            AudioTrackResponse("2", "Track2", "url2")
+        )
+        coEvery { api.getRecommendedMusic() } returns responses
+
+        val result = repository.getRecommendedMusic().first()
+
+        val expected = listOf(
+            AudioTrack("1", "Track1", "url1"),
+            AudioTrack("2", "Track2", "url2")
+        )
+
+        assertEquals(expected, result)
+    }
 }

--- a/app/src/test/java/com/psy/dear/data/repository/FakeContentRepository.kt
+++ b/app/src/test/java/com/psy/dear/data/repository/FakeContentRepository.kt
@@ -12,15 +12,18 @@ class FakeContentRepository : ContentRepository {
     private val articlesFlow = MutableStateFlow<List<Article>>(emptyList())
     private val audioFlow = MutableStateFlow<List<AudioTrack>>(emptyList())
     private val moodMusicFlow = MutableStateFlow<List<AudioTrack>>(emptyList())
+    private val recommendedFlow = MutableStateFlow<List<AudioTrack>>(emptyList())
     private val quotesFlow = MutableStateFlow<List<MotivationalQuote>>(emptyList())
 
     fun setArticles(list: List<Article>) { articlesFlow.value = list }
     fun setAudio(list: List<AudioTrack>) { audioFlow.value = list }
     fun setMoodMusic(list: List<AudioTrack>) { moodMusicFlow.value = list }
+    fun setRecommended(list: List<AudioTrack>) { recommendedFlow.value = list }
     fun setQuotes(list: List<MotivationalQuote>) { quotesFlow.value = list }
 
     override fun getArticles(): Flow<List<Article>> = articlesFlow.asStateFlow()
     override fun getAudioTracks(): Flow<List<AudioTrack>> = audioFlow.asStateFlow()
     override fun getMoodMusic(mood: String): Flow<List<AudioTrack>> = moodMusicFlow.asStateFlow()
+    override fun getRecommendedMusic(): Flow<List<AudioTrack>> = recommendedFlow.asStateFlow()
     override fun getQuotes(): Flow<List<MotivationalQuote>> = quotesFlow.asStateFlow()
 }


### PR DESCRIPTION
## Summary
- add `getRecommendedMusic` Retrofit call
- expose recommended music from `ContentRepository`
- implement API in `ContentRepositoryImpl`
- support new method in fake repo
- add `GetRecommendedMusicUseCase`
- test new repository method

## Testing
- `gradle test` *(fails: SDK location not found)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c32fdc0708324ac4d954c3056477c