### PR TITLE
Update music recommendations in home flow

### DIFF
--- a/app/src/main/java/com/psy/dear/domain/use_case/content/UseCases.kt
+++ b/app/src/main/java/com/psy/dear/domain/use_case/content/UseCases.kt
@@ -3,6 +3,7 @@ package com.psy.dear.domain.use_case.content
 import com.psy.dear.domain.model.Article
 import com.psy.dear.domain.model.AudioTrack
 import com.psy.dear.domain.model.MotivationalQuote
+import com.psy.dear.domain.model.Journal
 import com.psy.dear.domain.repository.ContentRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -20,7 +21,11 @@ class GetMoodMusicUseCase @Inject constructor(private val repo: ContentRepositor
 }
 
 class GetRecommendedMusicUseCase @Inject constructor(private val repo: ContentRepository) {
-    operator fun invoke(): Flow<List<AudioTrack>> = repo.getRecommendedMusic()
+    operator fun invoke(journals: List<Journal>): Flow<List<AudioTrack>> {
+        // Saat ini daftar jurnal belum digunakan di repository, namun disediakan
+        // agar logika rekomendasi dapat memanfaatkannya di masa depan
+        return repo.getRecommendedMusic()
+    }
 }
 
 class GetQuotesUseCase @Inject constructor(private val repo: ContentRepository) {

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeCards.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeCards.kt
@@ -128,7 +128,7 @@ fun AudioCard(track: AudioTrack, modifier: Modifier = Modifier, onClick: () -> U
 }
 
 @Composable
-fun MoodMusicCard(track: AudioTrack, modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
+fun RecommendedMusicCard(track: AudioTrack, modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
     Card(
         onClick = onClick,
         modifier = modifier

--- a/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/home/HomeScreen.kt
@@ -82,15 +82,15 @@ private fun HomeDashboard(state: HomeState, navController: NavController) {
         item { GreetingCard(userName = state.username) }
         item { JournalPromptCard { navController.navigate(Screen.JournalEditor.createRoute(null)) } }
 
-        if (state.moodTracks.isNotEmpty()) {
+        if (state.recommendedTracks.isNotEmpty()) {
             item {
-                MoodMusicCard(
-                    track = state.moodTracks.first(),
+                RecommendedMusicCard(
+                    track = state.recommendedTracks.first(),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 8.dp),
                     onClick = {
-                        val track = state.moodTracks.first()
+                        val track = state.recommendedTracks.first()
                         navController.navigate(
                             Screen.AudioPlayer.createRoute(url = track.url, title = track.title)
                         )

--- a/app/src/test/java/com/psy/dear/presentation/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/psy/dear/presentation/home/HomeViewModelTest.kt
@@ -12,7 +12,7 @@ import com.psy.dear.domain.use_case.journal.GetJournalsUseCase
 import com.psy.dear.domain.use_case.journal.SyncJournalsUseCase
 import com.psy.dear.domain.use_case.content.GetArticlesUseCase
 import com.psy.dear.domain.use_case.content.GetAudioTracksUseCase
-import com.psy.dear.domain.use_case.content.GetMoodMusicUseCase
+import com.psy.dear.domain.use_case.content.GetRecommendedMusicUseCase
 import com.psy.dear.domain.use_case.content.GetQuotesUseCase
 import com.psy.dear.domain.use_case.user.GetUserProfileUseCase
 import com.psy.dear.util.TestCoroutineRule
@@ -42,7 +42,7 @@ class HomeViewModelTest {
     private lateinit var syncJournalsUseCase: SyncJournalsUseCase
     private lateinit var getArticles: GetArticlesUseCase
     private lateinit var getAudio: GetAudioTracksUseCase
-    private lateinit var getMoodMusic: GetMoodMusicUseCase
+    private lateinit var getRecommendedMusic: GetRecommendedMusicUseCase
     private lateinit var getQuotes: GetQuotesUseCase
     private lateinit var getUserProfile: GetUserProfileUseCase
 
@@ -55,7 +55,7 @@ class HomeViewModelTest {
         syncJournalsUseCase = SyncJournalsUseCase(fakeRepository)
         getArticles = GetArticlesUseCase(fakeContentRepo)
         getAudio = GetAudioTracksUseCase(fakeContentRepo)
-        getMoodMusic = GetMoodMusicUseCase(fakeContentRepo)
+        getRecommendedMusic = GetRecommendedMusicUseCase(fakeContentRepo)
         getQuotes = GetQuotesUseCase(fakeContentRepo)
         getUserProfile = GetUserProfileUseCase(fakeUserRepo)
 
@@ -67,7 +67,7 @@ class HomeViewModelTest {
             syncJournalsUseCase,
             getArticles,
             getAudio,
-            getMoodMusic,
+            getRecommendedMusic,
             getQuotes,
             getUserProfile
         )


### PR DESCRIPTION
## Summary
- replace mood-based music with generic recommendations
- rename `moodTracks` state to `recommendedTracks`
- update `HomeViewModel` logic to fetch recommendations after loading journals
- rename UI card to `RecommendedMusicCard` and update `HomeScreen`
- adjust unit tests for new use case

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c34f2d99c8324bf504ad1a39b7a1d