### PR TITLE
Handle empty music recommendation results

### DIFF
--- a/backend/app/api/v1/music.py
+++ b/backend/app/api/v1/music.py
@@ -103,6 +103,7 @@ async def recommend_music(
             musics.append(schemas.AudioTrack(id=idx, title=title, url=streaming_url))
 
     if not musics:
-        raise HTTPException(status_code=404, detail="No music found")
+        # When no music is found, return an empty list instead of a 404 error
+        return []
 
     return musics

--- a/backend/tests/test_music_api.py
+++ b/backend/tests/test_music_api.py
@@ -67,3 +67,24 @@ def test_music_recommend_uses_keyword_and_journals(client, monkeypatch):
     assert len(captured["journals"]) == 3
     assert captured["query"] == "lofi"
 
+
+def test_music_recommend_returns_empty_list_when_no_results(client, monkeypatch):
+    def fake_get_multi_by_owner(db, owner_id: int, skip: int = 0, limit: int = 100):
+        return []
+
+    async def fake_generate_keyword(self, journals):
+        return "lofi"
+
+    def fake_search(self, query, filter="songs", limit=20):
+        return []
+
+    monkeypatch.setattr(crud.journal, "get_multi_by_owner", fake_get_multi_by_owner)
+    monkeypatch.setattr(MusicKeywordService, "generate_keyword", fake_generate_keyword)
+    monkeypatch.setattr(YTMusic, "search", fake_search)
+
+    client_app, _ = client
+    resp = client_app.get("/api/v1/music/recommend")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+


### PR DESCRIPTION
## Summary
- return an empty list instead of 404 when no recommendations are found
- add regression test for empty recommendation list

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685c914297448324924ad2c94e5a4183