### PR TITLE
Improve recommended music fetch logic

### DIFF
--- a/app/src/test/java/com/psy/dear/data/repository/FakeJournalRepository.kt
+++ b/app/src/test/java/com/psy/dear/data/repository/FakeJournalRepository.kt
@@ -24,6 +24,10 @@ class FakeJournalRepository : JournalRepository {
         refreshFlow()
     }
 
+    fun emitUnchanged() {
+        refreshFlow()
+    }
+
     private fun refreshFlow() {
         journalsFlow.value = journals
     }


### PR DESCRIPTION
## Summary
- debounce and check journal updates before requesting recommended tracks
- expose `emitUnchanged` in `FakeJournalRepository`
- assert recommended music is fetched once when journals don't change

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685c92260f0483249f6fe8d1fc740bea