### PR TITLE
Update test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,17 @@ The chat endpoint performs a basic emotion analysis on each message. The detecte
 
 ## Running Tests
 
-Install the backend dependencies first; the tests require the packages listed in `backend/requirements.txt`:
+Before running the tests you must install the backend requirements:
 
 ```bash
 pip install -r backend/requirements.txt
 pip install pytest pytest-asyncio
+```
+
+You can also use the helper script:
+
+```bash
+./scripts/install-test-deps.sh
 ```
 
 Run the suite with:

--- a/scripts/install-test-deps.sh
+++ b/scripts/install-test-deps.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Install packages required for running the test suite.
+set -e
+pip install -r backend/requirements.txt
+pip install pytest pytest-asyncio


### PR DESCRIPTION
## Summary
- expand README's test section with explicit install instructions
- add a helper script for installing test dependencies

## Testing
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb8c0e8c0832494e1ebea3e016790