### PR TITLE
docs: clarify backend setup

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -12,6 +12,10 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+> **Note**: Running `pip install -r requirements.txt` is mandatory before
+> starting Uvicorn. Omitting it can lead to import errors such as
+> `ModuleNotFoundError` if required packages are missing.
+
 Run the development server from within this directory:
 
 ```bash


### PR DESCRIPTION
## Summary
- mention that `pip install -r requirements.txt` must be run before starting Uvicorn
- note that missing packages cause import errors like `ModuleNotFoundError`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685cbd2b34148324ab183ddf173abd13