### PR TITLE
Add backend env example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,10 @@
+# Example environment variables for Dear Diary backend
+# Copy this file to .env and update values as needed
+
+OPENROUTER_API_KEY=sk-your-key               # API key for OpenRouter
+PLANNER_MODEL_NAME=mistralai/mistral-7b-instruct  # conversation planner model
+GENERATOR_MODEL_NAME=google/gemma-7b-it           # response generator model
+APP_SITE_URL=https://yourdomain.com               # URL reported to OpenRouter
+APP_NAME=Dear Diary                               # application name
+OAUTH_CLIENT_ID=                                  # optional YouTube OAuth client ID
+OAUTH_CLIENT_SECRET=                              # optional YouTube OAuth client secret

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,3 +21,8 @@ Run the development server from within this directory:
 ```bash
 uvicorn app.main:app --reload
 ```
+
+## Configuration
+
+Copy `.env.example` to `.env` and edit the values before running the server.
+The file lists all environment variables used by `app/core/config.py`.


### PR DESCRIPTION
## Summary
- add `.env.example` with key placeholders
- update backend README on configuration

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685dde4100c483248f0691d0c62239bf