### PR TITLE
Fix ytmusic oauth instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ pip install -r backend/requirements.txt
 ```bash
 cd backend
 python - <<'EOF'
-from ytmusicapi import YTMusic
-YTMusic.setup_oauth()
+from ytmusicapi import setup_oauth
+setup_oauth()
 EOF
 cd ..
 ```


### PR DESCRIPTION
## Summary
- update README to use module-level `setup_oauth()`

## Testing
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_685de21e6ef88324b489072584c68424