### PR TITLE
Add docstring to music keyword service

### DIFF
--- a/backend/app/services/music_keyword_service.py
+++ b/backend/app/services/music_keyword_service.py
@@ -1,3 +1,5 @@
+"""Utilities for generating a music keyword suggestion."""
+
 import httpx
 import structlog
 from typing import List, Dict


### PR DESCRIPTION
## Summary
- add a short module docstring to `music_keyword_service.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de46a7ffc8324a2d85aa9a5796f1c