### PR TITLE
Fix migration parameter name

### DIFF
--- a/app/src/main/java/com/psy/dear/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/psy/dear/data/local/AppDatabase.kt
@@ -22,8 +22,8 @@ abstract class AppDatabase : RoomDatabase() {
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL(
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
                     "CREATE TABLE IF NOT EXISTS `chat_messages` (" +
                         "`id` TEXT NOT NULL, " +
                         "`role` TEXT NOT NULL, " +
@@ -36,14 +36,14 @@ abstract class AppDatabase : RoomDatabase() {
         }
 
         val MIGRATION_2_3 = object : Migration(2, 3) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("ALTER TABLE `chat_messages` ADD COLUMN `emotion` TEXT")
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `chat_messages` ADD COLUMN `emotion` TEXT")
             }
         }
 
         val MIGRATION_3_4 = object : Migration(3, 4) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("ALTER TABLE `chat_messages` ADD COLUMN `isFlagged` INTEGER NOT NULL DEFAULT 0")
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `chat_messages` ADD COLUMN `isFlagged` INTEGER NOT NULL DEFAULT 0")
             }
         }
     }


### PR DESCRIPTION
## Summary
- rename `database` parameter to `db` in all `Migration.migrate` overrides

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e4161a8e48324aebf5c9df6c32f41