### PR TITLE
Remove unused context from AudioPlayerScreen

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/content/AudioPlayerScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/content/AudioPlayerScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -31,7 +30,6 @@ fun AudioPlayerScreen(
     trackUrl: String,
     homeViewModel: HomeViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
     val state by homeViewModel.state.collectAsState()
     val tracks = state.audio + state.recommendedTracks
     var currentIndex by remember(tracks, trackUrl) {


### PR DESCRIPTION
## Summary
- cleanup: delete unused `LocalContext` reference in `AudioPlayerScreen`

## Testing
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_685e459cddac83248d73788e68945de0