### PR TITLE
Remove unused NavController parameters

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/growth/GrowthScreen.kt
@@ -9,14 +9,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavController
 import com.psy.dear.domain.model.GrowthStatistics
 import com.psy.dear.core.asString
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GrowthScreen(
-    navController: NavController,
     viewModel: GrowthViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsState()

--- a/app/src/main/java/com/psy/dear/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/main/MainScreen.kt
@@ -78,8 +78,8 @@ fun MainScreen(rootNavController: NavHostController) {
                     }
                 )
             }
-            composable(Screen.Growth.route) { GrowthScreen(navController = mainNavController) }
-            composable(Screen.Services.route) { ServicesScreen(navController = mainNavController) }
+            composable(Screen.Growth.route) { GrowthScreen() }
+            composable(Screen.Services.route) { ServicesScreen() }
             composable(Screen.Profile.route) { ProfileScreen(navController = mainNavController) }
 
             composable(Screen.JournalEditor.route) { JournalEditorScreen(navController = mainNavController) }

--- a/app/src/main/java/com/psy/dear/presentation/services/ServicesScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/services/ServicesScreen.kt
@@ -6,11 +6,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ServicesScreen(navController: NavController) {
+fun ServicesScreen() {
     Scaffold(
         topBar = { TopAppBar(title = { Text("Layanan") }) }
     ) { padding ->

--- a/app/src/main/java/com/psy/dear/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/settings/SettingsScreen.kt
@@ -2,9 +2,8 @@ package com.psy.dear.presentation.settings
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
 
 @Composable
-fun SettingsScreen(navController: NavController) {
+fun SettingsScreen() {
     Text("Settings Screen Placeholder")
 }


### PR DESCRIPTION
## Summary
- drop unused NavController parameters from Growth, Services and Settings screens
- update MainScreen to call the screens without passing NavController

## Testing
- `./gradlew test` *(fails: could not find Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_685e469f9848832488cd35ea65943b39