### PR TITLE
Fix JournalDetailScreen back navigation

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/journal_detail/JournalDetailScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/journal_detail/JournalDetailScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.*
@@ -62,7 +62,7 @@ fun JournalDetailScreen(
                 title = { Text(journal?.title ?: "Detail") },
                 navigationIcon = {
                     IconButton(onClick = { navController.navigateUp() }) {
-                        Icon(Icons.Outlined.ArrowBack, contentDescription = "Kembali")
+                        Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Kembali")
                     }
                 },
                 actions = {
@@ -89,7 +89,7 @@ fun JournalDetailScreen(
                 Text(it.title, style = MaterialTheme.typography.headlineMedium)
                 Spacer(Modifier.height(8.dp))
                 Text(it.mood, style = MaterialTheme.typography.titleMedium)
-                Divider(modifier = Modifier.padding(vertical = 16.dp))
+                HorizontalDivider(modifier = Modifier.padding(vertical = 16.dp))
                 Text(it.content, style = MaterialTheme.typography.bodyLarge)
             }
         }


### PR DESCRIPTION
## Summary
- auto-mirror the back arrow icon
- swap out deprecated Divider for HorizontalDivider

## Testing
- `./gradlew assembleDebug` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_685e479b20508324924a05a4cf163603