### PR TITLE
Fix YTMusic optional auth

### DIFF
--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -19,6 +19,7 @@ def get_latest_journal(db: Session, user: models.User) -> str:
         db=db,
         owner_id=user.id,
         limit=1,
+        order_by="created_at desc",
     )
     return journals[0].content if journals else ""
 


### PR DESCRIPTION
## Summary
- support running music endpoints without oauth credentials
- ensure chat's `get_latest_journal` returns the most recent entry
- adjust journal lookup in music recommendation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685e6b4e285c832489abaf8b8bd7bdd0