### PR TITLE
Fix audio player current track resetting

### DIFF
--- a/app/src/main/java/com/psy/dear/presentation/content/AudioPlayerScreen.kt
+++ b/app/src/main/java/com/psy/dear/presentation/content/AudioPlayerScreen.kt
@@ -36,9 +36,11 @@ fun AudioPlayerScreen(
     homeViewModel: HomeViewModel = hiltViewModel()
 ) {
     val state by homeViewModel.state.collectAsState()
-    val tracks = state.audio + state.recommendedTracks
-    var currentIndex by remember(tracks, trackUrl) {
-        mutableStateOf(tracks.indexOfFirst { it.url == trackUrl }.takeIf { it >= 0 } ?: 0)
+    val tracks = remember(state.audio, state.recommendedTracks) {
+        state.audio + state.recommendedTracks
+    }
+    var currentIndex by remember(trackUrl) {
+        mutableStateOf(tracks.indexOfFirst { it.url == trackUrl }.coerceAtLeast(0))
     }
     val currentTrack = tracks.getOrNull(currentIndex)
 


### PR DESCRIPTION
## Summary
- ensure the list of tracks is remembered in `AudioPlayerScreen`
- remember `currentIndex` only by `trackUrl` so index changes persist

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7f7e6bb883249a76584aa8af09ce